### PR TITLE
fix get started url

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Open a command line terminal, **run in the project root directory**:
 yao start
 ```
 
-1. Open a browser, visit `https://127.0.0.1:5099/xiang/login/admin`,
+1. Open a browser, visit `http://127.0.0.1:5099/xiang/login/admin`,
 
 2. Enter the default username: `xiang@iqka.com`, password: `A123456p+`
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -99,7 +99,7 @@ yao run flows.setmenu
 yao start
 ```
 
-1. 打开浏览器, 访问 `https://127.0.0.1:5099/xiang/login/admin`，
+1. 打开浏览器, 访问 `http://127.0.0.1:5099/xiang/login/admin`，
 
 2. 输入默认用户名: `xiang@iqka.com`， 密码: `A123456p+`
 


### PR DESCRIPTION
修复 Get Started 示例中调试地址，对齐 terminal print。 https -> http 

相关代码

```go
  fmt.Println(color.WhiteString(L("Frontend")), color.GreenString(" http://%s%s/", host, port))
  fmt.Println(color.WhiteString(L("Dashboard")), color.GreenString(" http://%s%s/xiang/login/admin", host, port))
  fmt.Println(color.WhiteString(L("API")), color.GreenString(" http://%s%s/api", host, port))
  fmt.Println(color.WhiteString(L("Listening")), color.GreenString(" %s:%d", config.Conf.Host, config.Conf.Port))
```