### PR TITLE
Sui page add s:raw command

### DIFF
--- a/sui/core/parser.go
+++ b/sui/core/parser.go
@@ -176,7 +176,8 @@ func (parser *TemplateParser) parseElementAttrs(sel *goquery.Selection) {
 	}
 }
 
-// check if element attributes has the s:raw command, if true,ouput the raw data.
+// Check if the element attributes have the s:raw command.
+// If true, the sub-node will output the raw data instead of the escaped value.
 func checkIsRawElement(node *html.Node) bool {
 	if node.Parent != nil && len(node.Parent.Attr) > 0 {
 		for _, attr := range node.Parent.Attr {

--- a/sui/core/parser.go
+++ b/sui/core/parser.go
@@ -176,6 +176,17 @@ func (parser *TemplateParser) parseElementAttrs(sel *goquery.Selection) {
 	}
 }
 
+// check if element attributes has the s:raw command, if true,ouput the raw data.
+func checkIsRawElement(node *html.Node) bool {
+	if node.Parent != nil && len(node.Parent.Attr) > 0 {
+		for _, attr := range node.Parent.Attr {
+			if attr.Key == "s:raw" && attr.Val == "true" {
+				return true
+			}
+		}
+	}
+	return false
+}
 func (parser *TemplateParser) parseTextNode(node *html.Node) {
 	parser.sequence = parser.sequence + 1
 	res, hasStmt := parser.data.Replace(node.Data)
@@ -184,6 +195,9 @@ func (parser *TemplateParser) parseTextNode(node *html.Node) {
 		bindings := strings.TrimSpace(node.Data)
 		key := fmt.Sprintf("%v", parser.sequence)
 		if bindings != "" {
+			if checkIsRawElement(node) {
+				node.Type = html.RawNode
+			}
 			node.Parent.Attr = append(node.Parent.Attr, []html.Attribute{
 				{Key: "s:bind", Val: bindings},
 				{Key: "s:key-text", Val: key},


### PR DESCRIPTION
add the s:raw command to the sui page template,it will output the raw html code where use the template。

```html
<section>
    <div class="container mx-auto p-4">
        <div class="bg-white shadow-md rounded-lg p-4">
            <h1 class="text-3xl font-bold mb-4">{{post.title}}</h1>
            <img s:if="post.img != ''" src="{{ post.img }}" alt=" Post Image" class="object-cover rounded-md mb-4">
            <div class="flex justify-between items-center mb-4">
                <p class="text-gray-600">Created Time:{{post.created_at}}</p>
                <p class="text-gray-600">Created By:{{post.user_id}}</p>
            </div>
            <p class="text-gray-600 mb-4">{{post.description}}</p>

            <p class="mb-4" s:raw=true>{{post.content}}</p>

            <a href="/blog/index.sui" class="text-blue-500 font-semibold">Back to Post List</a>
        </div>
    </div>

</section><!-- JAVASCRIPTS -->

```