### PR TITLE
chore: Set full configuration by default for list widget

### DIFF
--- a/widgets/list/list.go
+++ b/widgets/list/list.go
@@ -219,8 +219,17 @@ func (dsl *DSL) Xgen(data map[string]interface{}, excludes map[string]bool, quer
 		return nil, err
 	}
 
-	// full width default value
-	if _, has := dsl.Config["full"]; !has {
+	// ** WARNING **
+	// set the full configuration by default
+	// Temporary solution, Will be removed in the future
+	// should be set when the list is created
+	config := map[string]interface{}{}
+	if dsl.Config != nil {
+		for key, value := range dsl.Config {
+			config[key] = value
+		}
+	}
+	if _, has := config["full"]; !has {
 		dsl.Config["full"] = true
 	}
 
@@ -237,7 +246,7 @@ func (dsl *DSL) Xgen(data map[string]interface{}, excludes map[string]bool, quer
 
 	onChange := map[string]interface{}{} // Hooks
 	setting["fields"] = fields
-	setting["config"] = dsl.Config
+	setting["config"] = config
 
 	replacements := maps.Map{}
 	if query != nil {


### PR DESCRIPTION
Set the full configuration by default for the list widget. This is a temporary solution and will be removed in the future. The full configuration should be set when the list is created.