### PR TITLE
feat: Add hideLabel option to component and column DSL

### DIFF
--- a/widgets/component/component.go
+++ b/widgets/component/component.go
@@ -27,6 +27,11 @@ func (dsl DSL) Map() map[string]interface{} {
 		"type":  dsl.Type,
 		"props": map[string]interface{}(dsl.Props),
 	}
+
+	if dsl.HideLabel {
+		res["hideLabel"] = true
+	}
+
 	if dsl.Bind != "" {
 		res["bind"] = dsl.Bind
 	}

--- a/widgets/component/types.go
+++ b/widgets/component/types.go
@@ -2,10 +2,11 @@ package component
 
 // DSL the component DSL
 type DSL struct {
-	Bind    string   `json:"bind,omitempty"`
-	Type    string   `json:"type,omitempty"`
-	Compute *Compute `json:"compute,omitempty"`
-	Props   PropsDSL `json:"props,omitempty"`
+	Bind      string   `json:"bind,omitempty"`
+	HideLabel bool     `json:"hideLabel,omitempty"`
+	Type      string   `json:"type,omitempty"`
+	Compute   *Compute `json:"compute,omitempty"`
+	Props     PropsDSL `json:"props,omitempty"`
 }
 
 // Actions the actions

--- a/widgets/field/column.go
+++ b/widgets/field/column.go
@@ -112,6 +112,10 @@ func (column ColumnDSL) Map() map[string]interface{} {
 		"bind": column.Bind,
 	}
 
+	if column.HideLabel {
+		res["hideLabel"] = true
+	}
+
 	if column.Data != nil {
 		res["data"] = map[string]interface{}{"process": column.Data.Process, "query": column.Data.Query}
 	}

--- a/widgets/field/types.go
+++ b/widgets/field/types.go
@@ -18,13 +18,14 @@ type CloudProps map[string]component.CloudPropsDSL
 
 // ColumnDSL the field column dsl
 type ColumnDSL struct {
-	ID   string                   `json:"id,omitempty"`
-	Data *component.CloudPropsDSL `json:"$data,omitempty"`
-	Key  string                   `json:"key,omitempty"`
-	Bind string                   `json:"bind,omitempty"`
-	Link string                   `json:"link,omitempty"`
-	View *component.DSL           `json:"view,omitempty"`
-	Edit *component.DSL           `json:"edit,omitempty"`
+	ID        string                   `json:"id,omitempty"`
+	Data      *component.CloudPropsDSL `json:"$data,omitempty"`
+	Key       string                   `json:"key,omitempty"`
+	Bind      string                   `json:"bind,omitempty"`
+	Link      string                   `json:"link,omitempty"`
+	HideLabel bool                     `json:"hideLabel,omitempty"`
+	View      *component.DSL           `json:"view,omitempty"`
+	Edit      *component.DSL           `json:"edit,omitempty"`
 }
 
 type aliasColumnDSL ColumnDSL

--- a/widgets/form/form.go
+++ b/widgets/form/form.go
@@ -264,15 +264,24 @@ func (dsl *DSL) Xgen(data map[string]interface{}, excludes map[string]bool) (map
 		return nil, err
 	}
 
-	// full width default value
-	if _, has := dsl.Config["full"]; !has {
-		dsl.Config["full"] = true
+	// ** WARNING **
+	// set the full configuration by default
+	// Temporary solution, Will be removed in the future
+	// should be set when the list is created
+	config := map[string]interface{}{}
+	if dsl.Config != nil {
+		for key, value := range dsl.Config {
+			config[key] = value
+		}
+	}
+	if _, has := config["full"]; !has {
+		config["full"] = true
 	}
 
 	// Merge the layout config
 	if layout.Config != nil {
 		for key, value := range layout.Config {
-			dsl.Config[key] = value
+			config[key] = value
 		}
 	}
 
@@ -289,7 +298,7 @@ func (dsl *DSL) Xgen(data map[string]interface{}, excludes map[string]bool) (map
 
 	onChange := map[string]interface{}{} // Hooks
 	setting["fields"] = fields
-	setting["config"] = dsl.Config
+	setting["config"] = config
 
 	for _, cProp := range dsl.CProps {
 		err := cProp.Replace(setting, func(cProp component.CloudPropsDSL) interface{} {

--- a/widgets/list/list.go
+++ b/widgets/list/list.go
@@ -230,7 +230,7 @@ func (dsl *DSL) Xgen(data map[string]interface{}, excludes map[string]bool, quer
 		}
 	}
 	if _, has := config["full"]; !has {
-		dsl.Config["full"] = true
+		config["full"] = true
 	}
 
 	setting := map[string]interface{}{}


### PR DESCRIPTION
Add the hideLabel option to the component and column DSLs. This allows hiding the label for the respective widgets. The hideLabel option is set to true in the component and column DSLs when necessary.