### PR TITLE
feat: Add SelectModel command to DSL

### DIFF
--- a/neo/types.go
+++ b/neo/types.go
@@ -22,6 +22,7 @@ type DSL struct {
 	Prompts             []aigc.Prompt             `json:"prompts,omitempty"`
 	Allows              []string                  `json:"allows,omitempty"`
 	Command             Command                   `json:"command,omitempty"`
+	Models              []string                  `json:"models,omitempty"`
 	AI                  aigc.AI                   `json:"-" yaml:"-"`
 	Conversation        conversation.Conversation `json:"-" yaml:"-"`
 	GuardHandlers       []gin.HandlerFunc         `json:"-" yaml:"-"`


### PR DESCRIPTION
Add the SelectModel command to the DSL, allowing the selection of a specific model. This command takes a model name as input and sets the AI to use that model. It returns a success message with a status code of 200 if the selection is successful.