### PR TITLE
feat: Clear modules before loading shared library

### DIFF
--- a/script/script.go
+++ b/script/script.go
@@ -11,6 +11,7 @@ import (
 
 // Load 加载共享库
 func Load(cfg config.Config) error {
+	v8.CLearModules()
 	exts := []string{"*.js", "*.ts"}
 	err := application.App.Walk("scripts", func(root, file string, isdir bool) error {
 		if isdir {


### PR DESCRIPTION
Clear the modules before loading the shared library to ensure a clean state. This is necessary to avoid any conflicts or issues with previously loaded modules.