### PR TITLE
refactor: Update AI connector handling and add support for Moapi models

### DIFF
--- a/aigc/aigc.go
+++ b/aigc/aigc.go
@@ -2,6 +2,7 @@ package aigc
 
 import (
 	"fmt"
+	"strings"
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/yaoapp/gou/connector"
@@ -96,8 +97,17 @@ func (ai *DSL) Call(content string, user string, option map[string]interface{}) 
 // NewAI create a new AI
 func (ai *DSL) newAI() (AI, error) {
 
-	if ai.Connector == "" {
-		return nil, fmt.Errorf("%s connector is required", ai.ID)
+	if ai.Connector == "" || strings.HasPrefix(ai.Connector, "moapi") {
+		model := "gpt-3.5-turbo"
+		if ai.Connector != "" {
+			model = strings.TrimPrefix(ai.Connector, "moapi:")
+		}
+
+		mo, err := openai.NewMoapi(model)
+		if err != nil {
+			return nil, err
+		}
+		return mo, nil
 	}
 
 	conn, err := connector.Select(ai.Connector)

--- a/aigc/types.go
+++ b/aigc/types.go
@@ -10,7 +10,7 @@ import (
 type DSL struct {
 	ID        string   `json:"-" yaml:"-"`
 	Name      string   `json:"name,omitempty"`
-	Connector string   `json:"connector"`
+	Connector string   `json:"connector,omitempty"`
 	Process   string   `json:"process,omitempty"`
 	Prompts   []Prompt `json:"prompts"`
 	Optional  Optional `json:"optional,omitempty"`


### PR DESCRIPTION
The code changes in `aigc.go` and `types.go` refactor the AI connector handling in the `DSL` struct. The `Connector` field now accepts an optional `moapi` prefix, allowing for the selection of Moapi models. If the `Connector` field starts with `moapi`, the code initializes a new Moapi instance with the specified model. Additionally, the `Connector` field is now marked as `omitempty` in the `types.go` file.

This update improves the flexibility of the AI connector configuration and enables the use of Moapi models in the AI system.