### PR TITLE
refactor: Add default BuildContext if none provided in TranslateMarks…

### DIFF
--- a/sui/core/compile.go
+++ b/sui/core/compile.go
@@ -290,6 +290,10 @@ func (page *Page) TranslateMarks(ctx *BuildContext, option *BuildOption, doc *go
 		return nil
 	}
 
+	if ctx == nil {
+		ctx = NewBuildContext(nil)
+	}
+
 	if ctx.translations == nil {
 		ctx.translations = []Translation{}
 	}


### PR DESCRIPTION
… function