### PR TITLE
Securely update add yao.component.GetOptions and deprecated SelectOptions

### DIFF
--- a/widgets/component/component.go
+++ b/widgets/component/component.go
@@ -105,7 +105,7 @@ func (dsl *DSL) Parse() {
 		for key, val := range BackendOnlyProps[t] {
 			if dsl.Props.Has(key) {
 				for k, v := range val {
-					dsl.Props[k] = v
+					dsl.Props[k] = dsl.copy(v)
 				}
 			}
 		}
@@ -126,4 +126,31 @@ func (dsl *DSL) Clone() *DSL {
 		}
 	}
 	return &new
+}
+
+// Copy the component properties
+func (dsl *DSL) copy(v interface{}) interface{} {
+	var res interface{} = nil
+	switch v.(type) {
+	case map[string]interface{}:
+		// Clone the map
+		new := map[string]interface{}{}
+		for k1, v1 := range v.(map[string]interface{}) {
+			new[k1] = v1
+		}
+		res = new
+
+	case []interface{}:
+		// Clone the array
+		new := []interface{}{}
+		for _, v1 := range v.([]interface{}) {
+			new = append(new, dsl.copy(v1))
+		}
+		res = new
+
+	default:
+		res = v
+	}
+
+	return res
 }

--- a/widgets/component/process_test.go
+++ b/widgets/component/process_test.go
@@ -1,0 +1,225 @@
+package component
+
+import (
+	"testing"
+
+	jsoniter "github.com/json-iterator/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/yaoapp/gou/process"
+	"github.com/yaoapp/yao/config"
+	"github.com/yaoapp/yao/test"
+)
+
+func TestProcessGetOptions(t *testing.T) {
+	test.Prepare(t, config.Conf)
+	defer test.Clean()
+	props := prepare(t)
+
+	name := "yao.component.GetOptions"
+	for _, queryParam := range props {
+
+		args := []interface{}{
+			map[string]interface{}{},
+			map[string]interface{}{"query": queryParam},
+		}
+
+		p, err := process.Of(name, args...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = p.Execute()
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer p.Release()
+		res, ok := p.Value().([]Option)
+		if !ok {
+			t.Fatal("Result is not []Option")
+		}
+
+		if len(res) != 8 {
+			t.Fatal("Result length is not 8")
+		}
+
+		assert.Equal(t, "Category cat 1-active-1", res[0].Label)
+		assert.Equal(t, "1", res[0].Value)
+		assert.Equal(t, "active-1", res[0].Icon)
+
+		// With KEYWORDS
+		args = []interface{}{
+			map[string]interface{}{"keywords": "dog"},
+			map[string]interface{}{"query": queryParam},
+		}
+
+		p, err = process.Of(name, args...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = p.Execute()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res, ok = p.Value().([]Option)
+		if !ok {
+			t.Fatal("Result is not []Option")
+		}
+
+		if len(res) != 2 {
+			t.Fatal("Result length is not 2")
+		}
+
+		assert.Equal(t, "Category dog 7-active-7", res[0].Label)
+		assert.Equal(t, "7", res[0].Value)
+		assert.Equal(t, "active-7", res[0].Icon)
+
+		// With SELECTED
+		args = []interface{}{
+			map[string]interface{}{"selected": []interface{}{1}},
+			map[string]interface{}{"query": queryParam},
+		}
+
+		p, err = process.Of(name, args...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = p.Execute()
+		if err != nil {
+			t.Fatal(err)
+		}
+		res, ok = p.Value().([]Option)
+		if !ok {
+			t.Fatal("Result is not []Option")
+		}
+
+		if len(res) != 1 {
+			t.Fatal("Result length is not 1")
+		}
+
+		assert.Equal(t, "Category cat 1-active-1", res[0].Label)
+		assert.Equal(t, "1", res[0].Value)
+		assert.Equal(t, "active-1", res[0].Icon)
+
+		// With KEYWORDS and SELECTED
+		args = []interface{}{
+			map[string]interface{}{"keywords": "dog", "selected": []interface{}{1, 2}},
+			map[string]interface{}{"query": queryParam},
+		}
+
+		p, err = process.Of(name, args...)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = p.Execute()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res, ok = p.Value().([]Option)
+		if !ok {
+			t.Fatal("Result is not []Option")
+		}
+
+		if len(res) != 4 {
+			t.Fatal("Result length is not 4")
+		}
+
+		assert.Equal(t, "Category cat 1-active-1", res[0].Label)
+		assert.Equal(t, "1", res[0].Value)
+		assert.Equal(t, "active-1", res[0].Icon)
+		assert.Equal(t, "Category dog 7-active-7", res[2].Label)
+		assert.Equal(t, "7", res[2].Value)
+		assert.Equal(t, "active-7", res[2].Icon)
+	}
+}
+
+func TestProcessSelectOptions(t *testing.T) {
+
+	name := "yao.component.SelectOptions"
+
+	p, err := process.Of(name, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = p.Execute()
+	assert.Contains(t, err.Error(), "process yao.component.SelectOptions is deprecated, please use yao.component.GetOptions instead")
+}
+
+func prepare(t *testing.T) map[string]map[string]interface{} {
+	exportProcess()
+
+	// Prepare data for testing
+	err := process.New("models.category.Migrate", true).Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = process.New("models.category.Insert",
+		[]string{"name", "status"},
+		[][]interface{}{
+			{"Category cat 1", "active-1"},
+			{"Category cat 2", "active-2"},
+			{"Category cat 3", "active-3"},
+			{"Category cat 4", "active-4"},
+			{"Category cat 5", "active-5"},
+			{"Category cat 6", "active-6"},
+			{"Category dog 7", "active-7"},
+			{"Category dog 8", "active-8"},
+		}).Execute()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	queryParam := map[string]interface{}{}
+	queryDSL := map[string]interface{}{}
+	err = jsoniter.Unmarshal([]byte(`{
+		"labelField": "name",
+		"valueField": "id",
+		"iconField": "status",
+		"from": "category",
+		"wheres": [
+			{ "column": "name", "value": "[[ $KEYWORDS ]]", "op": "match" },
+			{
+				"method": "orwhere",
+				"column": "id",
+				"op": "in",
+				"value": "[[ $SELECTED ]]"
+			}
+		],
+		"limit": 20,
+	  	"labelFormat": "[[ $name ]]-[[ $status ]]", 
+        "valueFormat": "[[ $id ]]",
+        "iconFormat": "[[ $status ]]" 
+   }`), &queryParam)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = jsoniter.Unmarshal([]byte(`{
+	  	"engine": "query-test", 
+        "select": ["name as label", "id as value", "status as icon"],
+        "from": "category",
+        "wheres": [
+          { "field": "name", "match": "[[ $KEYWORDS ]]" },
+          { "or": true, "field":"id", "in":"[[ $SELECTED ]]" }
+        ],
+        "limit": 20,
+       	"labelFormat": "[[ $label ]]-[[ $icon ]]", 
+        "valueFormat": "[[ $value ]]",
+        "iconFormat": "[[ $icon ]]" 
+	}`), &queryDSL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return map[string]map[string]interface{}{
+		"queryParam": queryParam,
+		"queryDSL":   queryDSL,
+	}
+}

--- a/widgets/dashboard/dashboard_test.go
+++ b/widgets/dashboard/dashboard_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/yaoapp/yao/flow"
 	"github.com/yaoapp/yao/i18n"
 	"github.com/yaoapp/yao/test"
+	"github.com/yaoapp/yao/widgets/component"
 )
 
 func TestLoad(t *testing.T) {
@@ -40,4 +41,6 @@ func prepare(t *testing.T, language ...string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	component.Export()
 }

--- a/widgets/dashboard/process_test.go
+++ b/widgets/dashboard/process_test.go
@@ -1,7 +1,6 @@
 package dashboard
 
 import (
-	"fmt"
 	"net/url"
 	"testing"
 
@@ -10,9 +9,9 @@ import (
 	"github.com/yaoapp/gou/process"
 	"github.com/yaoapp/gou/session"
 	"github.com/yaoapp/kun/any"
-	"github.com/yaoapp/kun/maps"
 	"github.com/yaoapp/yao/config"
 	"github.com/yaoapp/yao/test"
+	"github.com/yaoapp/yao/widgets/component"
 )
 
 func TestProcessData(t *testing.T) {
@@ -33,12 +32,12 @@ func TestProcessComponent(t *testing.T) {
 	test.Prepare(t, config.Conf)
 	defer test.Clean()
 	prepare(t)
+	testData(t)
 
 	args := []interface{}{
 		"workspace",
 		"fields.filter.状态.edit.props.xProps",
 		"remote",
-		map[string]interface{}{"select": []string{"name", "status"}, "limit": 2},
 	}
 
 	res, err := process.New("yao.dashboard.Component", args...).Exec()
@@ -46,15 +45,13 @@ func TestProcessComponent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fmt.Println(res)
-
-	pets, ok := res.([]maps.MapStr)
+	pets, ok := res.([]component.Option)
 	assert.True(t, ok)
 	assert.Equal(t, 2, len(pets))
-	assert.Equal(t, "Cookie", pets[0]["name"])
-	assert.Equal(t, "checked", pets[0]["status"])
-	assert.Equal(t, "Baby", pets[1]["name"])
-	assert.Equal(t, "checked", pets[1]["status"])
+	assert.Equal(t, "Cookie", pets[0].Label)
+	assert.Equal(t, "checked", pets[0].Value)
+	assert.Equal(t, "Baby", pets[1].Label)
+	assert.Equal(t, "checked", pets[1].Value)
 
 	args = []interface{}{
 		"workspace",

--- a/widgets/table/process_test.go
+++ b/widgets/table/process_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yaoapp/yao/config"
 	"github.com/yaoapp/yao/helper"
 	"github.com/yaoapp/yao/test"
+	"github.com/yaoapp/yao/widgets/component"
 )
 
 func TestProcessSearch(t *testing.T) {
@@ -364,13 +365,6 @@ func TestProcessComponent(t *testing.T) {
 		"pet",
 		"fields.filter.状态.edit.props.xProps",
 		"remote",
-		map[string]interface{}{
-			"model":    "pet",
-			"label":    "name",
-			"value":    "status",
-			"wheres[]": `{"column":"id","op":"ge","value":0}`,
-			"limit":    "2",
-		},
 	}
 
 	res, err := process.New("yao.table.Component", args...).Exec()
@@ -378,13 +372,13 @@ func TestProcessComponent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pets, ok := res.([]map[string]interface{})
+	pets, ok := res.([]component.Option)
 	assert.True(t, ok)
 	assert.Equal(t, 2, len(pets))
-	assert.Equal(t, "Cookie", pets[0]["label"])
-	assert.Equal(t, "checked", pets[0]["value"])
-	assert.Equal(t, "Baby", pets[1]["label"])
-	assert.Equal(t, "checked", pets[1]["value"])
+	assert.Equal(t, "Cookie", pets[0].Label)
+	assert.Equal(t, "checked", pets[0].Value)
+	assert.Equal(t, "Baby", pets[1].Label)
+	assert.Equal(t, "checked", pets[1].Value)
 }
 
 func TestProcessComponentError(t *testing.T) {
@@ -525,7 +519,7 @@ func TestProcessXgenWithPermissions(t *testing.T) {
 	session.Global().Set("__permissions", map[string]interface{}{
 		"tables.pet": []string{
 			"8ca9bdf0fa2cbc8f1018f8566ed6ab5e", // fields.table.消费金额
-			"f03f1ae60c46dd6cdeda87b919a51d7e", // fields.filter.状态
+			"c5b1f06582e1dff3ac6d16822fdadd54", // fields.filter.状态
 			"b1483ade34cd51261817558114e74e3f", // filter.actions[0] 添加宠物
 			"e6a67850312980e8372e550c5b361097", // operation.actions[0] 查看
 		},


### PR DESCRIPTION
**Deprecation of yao.component.SelectOptions**

If you are using **yao.component.SelectOptions** in the Select component, **it is recommended to update immediately.**

yao.component.SelectOptions has a data access vulnerability, which may allow unauthorized access to arbitrary model data through the API.

Replace it with yao.component.GetOptions, which allows direct querying in the component using the query prop.

```json
{
  "bind": "where.status.in",
  "edit": {
    "type": "Select",
    "props": {
      "query": {
        "from": "pet",
        "select": ["status", "name"],
        "labelField": "name",
        "valueField": "status",
        "wheres": [{ "column": "id", "op": "ge", "value": 0 }],
        "limit": 2
      }
    }
}
```