### PR TITLE
Update message handling to ignore 'action' messages in Neo API assistant

### DIFF
--- a/neo/message/message.go
+++ b/neo/message/message.go
@@ -293,7 +293,7 @@ func (m *Message) AppendTo(contents *Contents) *Message {
 		contents.AppendFunction([]byte(m.Text))
 		return m
 
-	case "loading", "error": // Ignore loading and error messages
+	case "loading", "error", "action": // Ignore loading, action and error messages
 		return m
 
 	default:


### PR DESCRIPTION
- Modified the message handling logic to include 'action' messages in the ignore list alongside 'loading' and 'error' messages, improving the clarity of message processing.
- This change enhances the robustness of the Neo API assistant by ensuring that irrelevant message types are not processed, streamlining the overall message handling workflow.