### PR TITLE
Enhance tag parsing flexibility in Assistant loading

### DIFF
--- a/neo/assistant/load.go
+++ b/neo/assistant/load.go
@@ -365,8 +365,32 @@ func loadMap(data map[string]interface{}) (*Assistant, error) {
 	}
 
 	// tags
-	if v, ok := data["tags"].([]string); ok {
-		assistant.Tags = v
+	if v, has := data["tags"]; has {
+		switch vv := v.(type) {
+		case []string:
+			assistant.Tags = vv
+		case []interface{}:
+			var tags []string
+			for _, tag := range vv {
+				tags = append(tags, cast.ToString(tag))
+			}
+			assistant.Tags = tags
+
+		case interface{}:
+			raw, err := jsoniter.Marshal(vv)
+			if err != nil {
+				return nil, err
+			}
+			var tags []string
+			err = jsoniter.Unmarshal(raw, &tags)
+			if err != nil {
+				return nil, err
+			}
+			assistant.Tags = tags
+
+		case string:
+			assistant.Tags = []string{vv}
+		}
 	}
 
 	// options


### PR DESCRIPTION
- Improved tag handling in loadMap to support multiple input types
- Added support for parsing tags from []interface{}, string, and other JSON-compatible formats
- Utilized jsoniter for robust type conversion and marshaling
- Increased robustness of tag loading process for diverse input scenarios

This change enhances the flexibility of tag parsing during Assistant initialization, allowing more versatile data input methods.