### PR TITLE
Add support for reasoning content and thinking state in OpenAI streaming

### DIFF
--- a/neo/message/contents.go
+++ b/neo/message/contents.go
@@ -66,7 +66,7 @@ func (c *Contents) ScanTokens(currentID string, cb func(token string, id string,
 			c.UpdateType(c.token, map[string]interface{}{"text": text}, c.id)
 			c.NewText([]byte(tails), c.id) // Create new text with the tails
 			cb(c.token, c.id, false, text, tails)
-			c.token = "" // clear the token
+			c.ClearToken() // clear the token
 			return
 		}
 
@@ -86,6 +86,11 @@ func (c *Contents) ScanTokens(currentID string, cb func(token string, id string,
 			cb(name, c.id, true, text, "") // call the callback
 		}
 	}
+}
+
+// ClearToken clear the token
+func (c *Contents) ClearToken() {
+	c.token = ""
 }
 
 // RemoveLastEmpty remove the last empty data

--- a/neo/neo.go
+++ b/neo/neo.go
@@ -124,13 +124,16 @@ func (neo *DSL) GenerateWithAI(ctx chatctx.Context, input string, messageType st
 		}
 
 		errorRaw := ""
+		isFirstThink := true
+		isThinking := false
+		currentMessageID := ""
 		err := ast.Chat(c.Request.Context(), msgList, neo.Option, func(data []byte) int {
 			select {
 			case <-clientBreak:
 				return 0 // break
 
 			default:
-				msg := message.NewOpenAI(data)
+				msg := message.NewOpenAI(data, isThinking)
 				if msg == nil {
 					return 1 // continue
 				}
@@ -146,15 +149,61 @@ func (neo *DSL) GenerateWithAI(ctx chatctx.Context, input string, messageType st
 					return 0 // break
 				}
 
+				// for api reasoning_content response
+				if msg.Type == "think" {
+					if isFirstThink {
+						msg.Text = "<think>\n" + msg.Text // add the think begin tag
+						isFirstThink = false
+						isThinking = true
+					}
+				}
+
+				// for api reasoning_content response
+				if isThinking && msg.Type != "think" {
+					// add the think close tag
+					end := message.New().Map(map[string]interface{}{"text": "\n</think>\n", "type": "think", "delta": true})
+					end.Write(c.Writer)
+					end.ID = currentMessageID
+					end.AppendTo(contents)
+					isThinking = false
+
+					// Clear the token and make a new line
+					contents.NewText([]byte{}, currentMessageID)
+					contents.ClearToken()
+				}
+
 				// Append content and send message
 				msg.AppendTo(contents)
+
+				// Scan the tokens
+				contents.ScanTokens(currentMessageID, func(token string, id string, begin bool, text string, tails string) {
+					currentMessageID = id
+					msg.ID = id
+					msg.Type = token
+					msg.Text = ""                                    // clear the text
+					msg.Props = map[string]interface{}{"text": text} // Update props
+
+					// End of the token clear the text
+					if begin {
+						return
+					}
+
+					// New message with the tails
+					newMsg, err := message.NewString(tails, id)
+					if err != nil {
+						return
+					}
+					msgList = append(msgList, *newMsg)
+				})
+
 				if !silent {
 					value := msg.String()
 					if value != "" {
 						message.New().
 							Map(map[string]interface{}{
-								"text": value,
-								"done": msg.IsDone,
+								"text":  value,
+								"delta": true,
+								"done":  msg.IsDone,
 							}).
 							Write(c.Writer)
 					}

--- a/openai/types.go
+++ b/openai/types.go
@@ -16,6 +16,19 @@ type Message struct {
 	} `json:"choices,omitempty"`
 }
 
+// MessageWithReasoningContent is the response from OpenAI
+type MessageWithReasoningContent struct {
+	ID      string `json:"id,omitempty"`
+	Object  string `json:"object,omitempty"`
+	Created int64  `json:"created,omitempty"`
+	Model   string `json:"model,omitempty"`
+	Choices []struct {
+		Delta        map[string]interface{} `json:"delta,omitempty"`
+		Index        int                    `json:"index,omitempty"`
+		FinishReason string                 `json:"finish_reason,omitempty"`
+	} `json:"choices,omitempty"`
+}
+
 // ToolCalls is the response from OpenAI
 type ToolCalls struct {
 	ID      string `json:"id,omitempty"`


### PR DESCRIPTION
- Implemented handling of reasoning_content in OpenAI message parsing
- Added support for tracking thinking state with `<think>` tags
- Updated message generation to handle delta messages and thinking states
- Modified OpenAI API to support flexible base URL configuration
- Enhanced token scanning and message processing for reasoning content