### PR TITLE
Configure base URL for OpenAI API initialization

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -133,6 +133,7 @@ func NewMoapi(model string) (*OpenAI, error) {
 		model:        model,
 		host:         url,
 		organization: organization,
+		baseURL:      "/v1",
 		maxToken:     16384,
 	}, nil
 }


### PR DESCRIPTION
- Added default base URL "/v1" in NewMoapi method
- Supports flexible base URL configuration for OpenAI API client
- Complements previous work on API configuration and streaming improvements