### PR TITLE
Remove debug print statement in OpenAI message parsing

### DIFF
--- a/neo/message/message.go
+++ b/neo/message/message.go
@@ -232,7 +232,6 @@ func NewOpenAI(data []byte, isThinking bool) *Message {
 
 			msg.Text = text
 			msg.IsDone = chunk.Choices[0].FinishReason == "tool_calls" // is done when tool calls are finished
-			fmt.Printf("arguments: %s, finish_reason: %#v\n", arguments, chunk.Choices[0].FinishReason)
 			return msg
 		}
 


### PR DESCRIPTION
- Remove unnecessary debug print of arguments and finish reason
- Maintain clean and concise message processing logic
- Align with previous refactoring efforts to simplify code