### PR TITLE
Add support for passing arguments in assistant method calls

### DIFF
--- a/neo/assistant/call.go
+++ b/neo/assistant/call.go
@@ -247,6 +247,7 @@ func (obj *objectCall) run(info *v8go.FunctionCallbackInfo) *v8go.Value {
 	chatCtx.AssistantID = assistantID
 	chatCtx.ChatID = fmt.Sprintf("call_%s", uuid.New().String()) // New chat id
 	chatCtx.Silent = options.Silent
+	chatCtx.Args = goArgs // Arguments for call
 
 	// Define the callback function
 	var cb func(msg *chatMessage.Message) = nil

--- a/neo/context/context.go
+++ b/neo/context/context.go
@@ -28,6 +28,7 @@ type Context struct {
 	Upload      *FileUpload            `json:"upload,omitempty"`
 	Version     bool                   `json:"version,omitempty"` // Version support
 	RAG         bool                   `json:"rag,omitempty"`     // RAG support
+	Args        []interface{}          `json:"args,omitempty"`    // Arguments for call
 	SharedSpace plan.Space             `json:"-"`                 // Shared space
 }
 
@@ -123,6 +124,11 @@ func (ctx *Context) Map() map[string]interface{} {
 	// Retry mode
 	if ctx.Retry {
 		data["retry"] = ctx.Retry
+	}
+
+	// Arguments for call
+	if ctx.Args != nil && len(ctx.Args) > 0 {
+		data["args"] = ctx.Args
 	}
 
 	// Retry times


### PR DESCRIPTION
- Extend Context struct to include Args field for storing call arguments
- Modify objectCall.run to capture and store arguments in chat context
- Update context mapping to include arguments when present