### PR TITLE
Add type filtering for assistants in API and data loading

### DIFF
--- a/neo/api.go
+++ b/neo/api.go
@@ -962,6 +962,7 @@ func (neo *DSL) handleGenerateCustom(c *gin.Context) {
 func (neo *DSL) handleAssistantList(c *gin.Context) {
 	// Parse filter parameters
 	filter := store.AssistantFilter{
+		Type:     "assistant",
 		Page:     1,
 		PageSize: 20,
 	}
@@ -1106,6 +1107,7 @@ func (neo *DSL) handleAssistantDetail(c *gin.Context) {
 
 	filter := store.AssistantFilter{
 		AssistantID: assistantID,
+		Type:        "assistant",
 		Page:        1,
 		PageSize:    1,
 	}

--- a/neo/assistant/load.go
+++ b/neo/assistant/load.go
@@ -78,21 +78,7 @@ func LoadBuiltIn() error {
 			assistant.Sort = sort
 		}
 		if assistant.Tags == nil {
-			assistant.Tags = []string{"Built-in"}
-		}
-
-		// Check if the assistant has Built-in tag
-		hasBuiltIn := false
-		for _, tag := range assistant.Tags {
-			if tag == "Built-in" {
-				hasBuiltIn = true
-				break
-			}
-		}
-
-		// add Built-in tag if not exists
-		if !hasBuiltIn {
-			assistant.Tags = append(assistant.Tags, "Built-in")
+			assistant.Tags = []string{}
 		}
 
 		// Save the assistant
@@ -254,8 +240,10 @@ func LoadPath(path string) (*Assistant, error) {
 	// assistant_id
 	id := strings.ReplaceAll(strings.TrimPrefix(path, "/assistants/"), "/", ".")
 	data["assistant_id"] = id
-	data["type"] = "assistant"
 	data["path"] = path
+	if _, has := data["type"]; !has {
+		data["type"] = "assistant"
+	}
 
 	updatedAt := int64(0)
 

--- a/neo/store/types.go
+++ b/neo/store/types.go
@@ -48,6 +48,7 @@ type ChatGroupResponse struct {
 // Used for filtering and pagination when retrieving assistant lists
 type AssistantFilter struct {
 	Tags         []string `json:"tags,omitempty"`          // Filter by tags
+	Type         string   `json:"type,omitempty"`          // Filter by type
 	Keywords     string   `json:"keywords,omitempty"`      // Search in name and description
 	Connector    string   `json:"connector,omitempty"`     // Filter by connector
 	AssistantID  string   `json:"assistant_id,omitempty"`  // Filter by assistant ID

--- a/neo/store/xun.go
+++ b/neo/store/xun.go
@@ -1058,6 +1058,11 @@ func (conv *Xun) GetAssistants(filter AssistantFilter) (*AssistantResponse, erro
 		})
 	}
 
+	// Apply type filter if provided
+	if filter.Type != "" {
+		qb.Where("type", filter.Type)
+	}
+
 	// Apply connector filter if provided
 	if filter.Connector != "" {
 		qb.Where("connector", filter.Connector)
@@ -1259,7 +1264,7 @@ func (conv *Xun) DeleteAssistants(filter AssistantFilter) (int64, error) {
 // GetAssistantTags retrieves all unique tags from assistants
 func (conv *Xun) GetAssistantTags() ([]string, error) {
 	q := conv.newQuery().Table(conv.getAssistantTable())
-	rows, err := q.Select("tags").GroupBy("tags").Get()
+	rows, err := q.Select("tags").Where("type", "assistant").GroupBy("tags").Get()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Introduce 'Type' field in AssistantFilter for filtering assistant lists
- Update handleAssistantList and handleAssistantDetail methods to set 'Type' to 'assistant'
- Modify LoadPath function to ensure 'type' is set if not already present
- Adjust GetAssistants and GetAssistantTags methods to apply type filtering in queries