### PR TITLE
fix: Update processRead to return string representation of table data

### DIFF
--- a/widgets/table/process.go
+++ b/widgets/table/process.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/yaoapp/gou/application"
 	"github.com/yaoapp/gou/fs"
 	"github.com/yaoapp/gou/model"
 	gouProcess "github.com/yaoapp/gou/process"
@@ -370,12 +369,7 @@ func processUnload(process *gouProcess.Process) interface{} {
 func processRead(process *gouProcess.Process) interface{} {
 	process.ValidateArgNums(1)
 	tab := MustGet(process) // 0
-	source := map[string]interface{}{}
-	err := application.Parse(tab.file, tab.Read(), &source)
-	if err != nil {
-		exception.New(err.Error(), 500).Throw()
-	}
-	return source
+	return string(tab.Read())
 }
 
 // processExists yao.table.Exists table_name

--- a/widgets/table/process_test.go
+++ b/widgets/table/process_test.go
@@ -637,7 +637,7 @@ func TestProcessRead(t *testing.T) {
 
 	res := process.New("yao.table.Read", "pet").Run()
 	assert.NotNil(t, res)
-	assert.Equal(t, "::Pet Admin", res.(map[string]interface{})["name"])
+	assert.Contains(t, res.(string), "::Pet Admin")
 }
 
 func TestProcessList(t *testing.T) {


### PR DESCRIPTION
- Modify processRead function to return the string output of the table read operation instead of a map.
- Update unit test for TestProcessRead to check for substring presence in the result, ensuring correct functionality.