### PR TITLE
fix: Enhance message role handling in Assistant API and object

### DIFF
--- a/neo/assistant/api.go
+++ b/neo/assistant/api.go
@@ -1086,6 +1086,11 @@ func (ast *Assistant) requestMessages(ctx context.Context, messages []chatMessag
 
 		role := message.Role
 		if role == "" {
+			if os.Getenv("YAO_AGENT_PRINT_REQUEST_MESSAGES") == "true" {
+				raw, _ := jsoniter.MarshalToString(message)
+				color.Red("Request Message Error, role is empty:")
+				fmt.Println(raw)
+			}
 			return nil, fmt.Errorf("role must be string")
 		}
 

--- a/neo/assistant/object.go
+++ b/neo/assistant/object.go
@@ -290,6 +290,11 @@ func jsSend(info *v8go.FunctionCallbackInfo) *v8go.Value {
 			return bridge.JsException(info.Context(), err.Error())
 		}
 
+		// Set the role to assistant
+		if msg.Role == "" {
+			msg.Role = "assistant"
+		}
+
 		// Append the message to the contents
 		if saveHistory {
 			msg.AppendTo(global.Contents)
@@ -299,6 +304,11 @@ func jsSend(info *v8go.FunctionCallbackInfo) *v8go.Value {
 
 	case map[string]interface{}:
 		msg := message.New().Map(v)
+		if msg.Role == "" {
+			msg.Role = "assistant"
+		}
+
+		// Append the message to the contents
 		if saveHistory {
 			msg.AppendTo(global.Contents)
 		}
@@ -332,10 +342,6 @@ func jsReplace(info *v8go.FunctionCallbackInfo) *v8go.Value {
 	}
 
 	replaced, _ := sui.Data(data).Replace(tmpl)
-	if err != nil {
-		return bridge.JsException(info.Context(), err.Error())
-	}
-
 	jsReplaced, err := bridge.JsValue(info.Context(), replaced)
 	if err != nil {
 		return bridge.JsException(info.Context(), err.Error())


### PR DESCRIPTION
- Add logging for empty message roles in requestMessages function to aid debugging.
- Default message role to "assistant" if not provided in jsSend function, ensuring consistent message handling.
- Clean up error handling in jsReplace function for improved clarity.