### PR TITLE
feat: Enhance getTimestamp function to support time.Time type

### DIFF
--- a/neo/assistant/utils.go
+++ b/neo/assistant/utils.go
@@ -33,6 +33,9 @@ func getTimestamp(v interface{}) (int64, error) {
 			return ts, nil
 		}
 
+	case time.Time:
+		return v.UnixNano(), nil
+
 	case nil:
 		return 0, nil
 	}


### PR DESCRIPTION
- Add case for time.Time in getTimestamp function to return Unix timestamp in nanoseconds, improving versatility in timestamp handling.