### PR TITLE
refactor: Rename BeginAt and EndAt fields for consistency in message …

### DIFF
--- a/neo/message/contents.go
+++ b/neo/message/contents.go
@@ -56,7 +56,7 @@ type ScanCallbackParams struct {
 	Token     string
 	MessageID string
 	TokenID   string
-	BeginAt   int64
+	BeganAt   int64
 	EndAt     int64
 	Begin     bool
 	End       bool
@@ -73,7 +73,7 @@ func NewContents() *Contents {
 }
 
 // ScanTokens scan the tokens
-func (c *Contents) ScanTokens(messageID string, tokenID string, beginAt int64, cb func(params ScanCallbackParams)) {
+func (c *Contents) ScanTokens(messageID string, tokenID string, beganAt int64, cb func(params ScanCallbackParams)) {
 
 	text := strings.TrimSpace(c.Text())
 
@@ -96,13 +96,13 @@ func (c *Contents) ScanTokens(messageID string, tokenID string, beginAt int64, c
 
 			c.UpdateType(tokenType, map[string]interface{}{"text": text}, extra)
 			c.NewText([]byte(tails), extra) // Create new text with the tails
-			cb(ScanCallbackParams{Token: tokenType, MessageID: c.id, TokenID: tokenID, BeginAt: beginAt, Begin: false, End: true, Text: text, Tails: tails, EndAt: extra.End})
+			cb(ScanCallbackParams{Token: tokenType, MessageID: c.id, TokenID: tokenID, BeganAt: beganAt, Begin: false, End: true, Text: text, Tails: tails, EndAt: extra.End})
 			c.ClearToken(c.token) // clear the token
 			return
 		}
 
 		// call the callback for the scanning of the token
-		cb(ScanCallbackParams{Token: tokenType, MessageID: c.id, TokenID: tokenID, BeginAt: beginAt, Begin: false, End: false, Text: text, Tails: "", EndAt: 0})
+		cb(ScanCallbackParams{Token: tokenType, MessageID: c.id, TokenID: tokenID, BeganAt: beganAt, Begin: false, End: false, Text: text, Tails: "", EndAt: 0})
 		return
 	}
 
@@ -124,14 +124,14 @@ func (c *Contents) ScanTokens(messageID string, tokenID string, beginAt int64, c
 			// First time scanning the token, generate the token ID and begin time
 			if tokenID == "" || tokenType != name {
 				tokenID = GenerateNumericID("T")
-				beginAt = time.Now().UnixNano()
+				beganAt = time.Now().UnixNano()
 				begin = true
 				c.token = tokenID
 				c.AppendToken(tokenID, name)
-				c.UpdateType(name, map[string]interface{}{"text": text, "id": tokenID}, Extra{ID: c.id, Begin: beginAt, End: beginAt})
+				c.UpdateType(name, map[string]interface{}{"text": text, "id": tokenID}, Extra{ID: c.id, Begin: beganAt, End: beganAt})
 			}
 
-			cb(ScanCallbackParams{Token: name, MessageID: c.id, TokenID: tokenID, BeginAt: beginAt, Begin: begin, End: false, Text: text, Tails: "", EndAt: 0}) // call the callback
+			cb(ScanCallbackParams{Token: name, MessageID: c.id, TokenID: tokenID, BeganAt: beganAt, Begin: begin, End: false, Text: text, Tails: "", EndAt: 0}) // call the callback
 		}
 	}
 }

--- a/neo/message/message.go
+++ b/neo/message/message.go
@@ -44,8 +44,8 @@ type Message struct {
 	IsBeginTool     bool                   `json:"-"`                          // is new tool for the message for native tool_calls
 	IsEndTool       bool                   `json:"-"`                          // is end tool for the message for native tool_calls
 	Result          any                    `json:"result,omitempty"`           // result for the message
-	BeginAt         int64                  `json:"begin_at,omitempty"`         // begin at for the message // timestamp
-	EndAt           int64                  `json:"end_at,omitempty"`           // end at for the message // timestamp
+	Begin           int64                  `json:"begin,omitempty"`            // begin at for the message // timestamp
+	End             int64                  `json:"end,omitempty"`              // end at for the message // timestamp
 }
 
 // Mention represents a mention
@@ -423,10 +423,10 @@ func (m *Message) AppendTo(contents *Contents) *Message {
 	case "text", "think", "tool", "tool_calls_native":
 		if m.Text != "" {
 			if m.IsNew {
-				contents.NewText([]byte(m.Text), Extra{ID: m.ID, Begin: m.BeginAt, End: m.EndAt})
+				contents.NewText([]byte(m.Text), Extra{ID: m.ID, Begin: m.Begin, End: m.End})
 				return m
 			}
-			contents.AppendText([]byte(m.Text), Extra{ID: m.ID, Begin: m.BeginAt, End: m.EndAt})
+			contents.AppendText([]byte(m.Text), Extra{ID: m.ID, Begin: m.Begin, End: m.End})
 			return m
 		}
 		return m

--- a/neo/neo.go
+++ b/neo/neo.go
@@ -129,7 +129,7 @@ func (neo *DSL) GenerateWithAI(ctx chatctx.Context, input string, messageType st
 		isThinking := false
 		currentMessageID := ""
 		tokenID := ""
-		beginAt := int64(0)
+		beganAt := int64(0)
 		err := ast.Chat(c.Request.Context(), msgList, neo.Option, func(data []byte) int {
 			select {
 			case <-clientBreak:
@@ -179,7 +179,7 @@ func (neo *DSL) GenerateWithAI(ctx chatctx.Context, input string, messageType st
 				msg.AppendTo(contents)
 
 				// Scan the tokens
-				contents.ScanTokens(currentMessageID, tokenID, beginAt, func(params message.ScanCallbackParams) {
+				contents.ScanTokens(currentMessageID, tokenID, beganAt, func(params message.ScanCallbackParams) {
 					currentMessageID = params.MessageID
 					msg.ID = params.MessageID
 					msg.Type = params.Token
@@ -188,13 +188,13 @@ func (neo *DSL) GenerateWithAI(ctx chatctx.Context, input string, messageType st
 
 					// End of the token clear the text
 					if params.Begin {
-						msg.BeginAt = beginAt
+						msg.Begin = beganAt
 						return
 					}
 
 					// End of the token clear the text
 					if params.End {
-						msg.EndAt = params.EndAt
+						msg.End = params.EndAt
 						return
 					}
 


### PR DESCRIPTION
…handling

- Change BeginAt and EndAt fields to Begin and End in Message struct for improved clarity.
- Update related methods and parameters across the codebase to reflect the new naming convention.
- Ensure consistency in timestamp handling within the ScanTokens function and message processing methods.