### PR TITLE
fix: Update client type constant for Android in context management

### DIFF
--- a/neo/context/context.go
+++ b/neo/context/context.go
@@ -59,8 +59,8 @@ const (
 	// ClientTypeWeb is the client type for Web (Default UI)
 	ClientTypeWeb = "web"
 
-	// ClientTypeSDK is the client type for SDK
-	ClientTypeSDK = "android"
+	// ClientTypeAndroid is the client type for Android
+	ClientTypeAndroid = "android"
 
 	// ClientTypeIOS is the client type for IOS
 	ClientTypeIOS = "ios"
@@ -82,7 +82,7 @@ const (
 var SupportedClientTypes = map[string]bool{
 	ClientTypeAgent:   true,
 	ClientTypeWeb:     true,
-	ClientTypeSDK:     true,
+	ClientTypeAndroid: true,
 	ClientTypeIOS:     true,
 	ClientTypeJSSDK:   true,
 	ClientTypeMacOS:   true,


### PR DESCRIPTION
- Renamed ClientTypeSDK to ClientTypeAndroid for clarity and consistency in client type definitions.
- Updated SupportedClientTypes map to reflect the change in client type naming.