### PR TITLE
fix: Update download URL for Yao binary in Dockerfiles

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -20,7 +20,7 @@ ARG ARCH
 RUN groupadd -r yao && useradd -r -g yao yao && \
     apt-get update && \
     apt-get install -y curl sudo procps net-tools
-RUN curl -fsSL "https://yao.moapi.ai/archives/yao-${VERSION}-linux-${ARCH}" > /usr/local/bin/yao && \
+RUN curl -fsSL "https://pub-80136338e60643edbb55c6ca8a689cf8.r2.dev/archives/yao-${VERSION}-linux-${ARCH}" > /usr/local/bin/yao && \
     chmod +x /usr/local/bin/yao && \
     mkdir -p /data/app
 

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -18,7 +18,7 @@ FROM alpine:latest
 ARG VERSION
 ARG ARCH
 RUN apk --no-cache add curl 
-RUN curl -fsSL "https://yao.moapi.ai/archives/yao-${VERSION}-linux-${ARCH}" > /usr/local/bin/yao && \
+RUN curl -fsSL "https://pub-80136338e60643edbb55c6ca8a689cf8.r2.dev/archives/yao-${VERSION}-linux-${ARCH}" > /usr/local/bin/yao && \
     chmod +x /usr/local/bin/yao && \
     addgroup -S yao && adduser -S -G yao yao && \
     mkdir -p /data/app && \


### PR DESCRIPTION
- Changed the download URL for the Yao binary in both development and production Dockerfiles to a new location.
- Ensured that the binary is still installed correctly with the appropriate permissions.