### PR TITLE
fix: Correct assistant ID handling in chat methods

### DIFF
--- a/neo/api.go
+++ b/neo/api.go
@@ -536,7 +536,7 @@ func (neo *DSL) handleChatLatest(c *gin.Context) {
 
 	// assistant_id is nil return the default assistant
 	if chat.Chat["assistant_id"] == nil {
-		chat.Chat["assistant_id"] = neo.Use
+		chat.Chat["assistant_id"] = neo.Use.Default
 
 		// Get the assistant info
 		ast, err := assistant.Get(neo.Use.Default)
@@ -549,7 +549,7 @@ func (neo *DSL) handleChatLatest(c *gin.Context) {
 		chat.Chat["assistant_avatar"] = ast.Avatar
 	}
 
-	chat.Chat["assistant_deleteable"] = neo.Use != chat.Chat["assistant_id"]
+	chat.Chat["assistant_deleteable"] = neo.Use.Default != chat.Chat["assistant_id"]
 	c.JSON(200, map[string]interface{}{"data": chat})
 	c.Done()
 }
@@ -579,7 +579,7 @@ func (neo *DSL) handleChatDetail(c *gin.Context) {
 
 	// assistant_id is nil return the default assistant
 	if chat.Chat["assistant_id"] == nil {
-		chat.Chat["assistant_id"] = neo.Use
+		chat.Chat["assistant_id"] = neo.Use.Default
 
 		// Get the assistant info
 		ast, err := assistant.Get(neo.Use.Default)


### PR DESCRIPTION
- Updated the assignment of assistant_id to use the Default value from neo.Use, ensuring consistent behavior when the assistant_id is nil.
- Adjusted the logic for determining assistant_deleteable to compare against the Default value, improving clarity and correctness in chat functionality.