### PR TITLE
chore: Update Go version in CI workflows to 1.24

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        go: [1.23]
+        go: [1.24]
         db: [MySQL8.0, MySQL5.7, SQLite3]
         redis: [4, 5, 6]
         mongo: ["6.0"]

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        go: [1.23]
+        go: [1.24]
         db: [MySQL8.0, MySQL5.7, SQLite3]
         redis: [4, 5, 6]
         mongo: ["6.0"]


### PR DESCRIPTION
- Updated the Go version in both `pr-test.yml` and `unit-test.yml` workflows from 1.23 to 1.24 to ensure compatibility with the latest features and improvements.