### PR TITLE
chore: Update .gitignore and Makefile for improved artifact management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ xgen/v1.0/*
 docker/build/test
 db
 *.sh
+data/bindata.go.bak
+share/const.go.bak
+share/const.goe


### PR DESCRIPTION
- Added backup entries for bindata.go and const.go in .gitignore to prevent accidental commits.
- Refactored Makefile to streamline CUI commit retrieval and ensure consistent versioning in artifact generation.
- Implemented backup and restoration of bindata.go and const.go during the release process for better safety.