### PR TITLE
chore: Update version and Go installation in CI workflows

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -7,7 +7,7 @@ on:
         description: "Version tags"
 
 env:
-  VERSION: 0.9.0
+  VERSION: 0.10.5
 
 jobs:
   build:

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -29,10 +29,10 @@ RUN apt-get update && \
     apt-get install -y git && \
     apt-get install -y unzip 
 
-# Install Go 1.24.0 
-RUN wget https://golang.org/dl/go1.24.0.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.24.0.linux-amd64.tar.gz && \
-    rm go1.24.0.linux-amd64.tar.gz
+# Install Go 1.24.3 
+RUN wget https://golang.org/dl/go1.24.3.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.24.3.linux-amd64.tar.gz && \
+    rm go1.24.3.linux-amd64.tar.gz
 
 # Install Node.js 18.x
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \


### PR DESCRIPTION
- Bumped the version from 0.9.0 to 0.10.5 in the macOS build workflow.
- Updated the Go installation in the Dockerfile from version 1.24.0 to 1.24.3 for improved compatibility and features.