### PR TITLE
chore: Remove --no-checksum-validation option from S3 copy command in…

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Push To R2 Cloudflare
         run: |
           for file in /data/*; do
-            aws s3 cp $file s3://$R2_BUCKET/archives/ --endpoint-url https://$R2_ACCOUNT_ID.r2.cloudflarestorage.com --no-checksum-validation
+            aws s3 cp $file s3://$R2_BUCKET/archives/ --endpoint-url https://$R2_ACCOUNT_ID.r2.cloudflarestorage.com
           done


### PR DESCRIPTION
… build-linux workflow

- Updated the S3 copy command in the build-linux.yml workflow to remove the --no-checksum-validation option, reverting to the previous behavior for consistency in file uploads.