### PR TITLE
Add attachment status management and filtering in neo package

### DIFF
--- a/neo/store/types.go
+++ b/neo/store/types.go
@@ -235,6 +235,7 @@ type AttachmentFilter struct {
 	Public       *bool    `json:"public,omitempty"`        // Filter by public status
 	Gzip         *bool    `json:"gzip,omitempty"`          // Filter by gzip compression
 	CollectionID string   `json:"collection_id,omitempty"` // Filter by knowledge collection ID
+	Status       string   `json:"status,omitempty"`        // Filter by processing status (uploading, uploaded, indexing, indexed, upload_failed, index_failed)
 	Keywords     string   `json:"keywords,omitempty"`      // Search in filename
 	Page         int      `json:"page,omitempty"`          // Page number, starting from 1
 	PageSize     int      `json:"pagesize,omitempty"`      // Items per page


### PR DESCRIPTION
- Introduced new status field in the attachment table to track processing states: uploading, uploaded, indexing, indexed, upload_failed, and index_failed.
- Added progress and error fields to provide detailed information during the attachment processing workflow.
- Implemented AttachmentFilter struct to support filtering attachments by status.
- Updated SaveAttachment and GetAttachments methods to handle new status and progress information.
- Enhanced tests to validate attachment status management and filtering functionality.