### PR TITLE
Add gzip option to ManagerOption struct and update app processing logic

### DIFF
--- a/neo/attachment/types.go
+++ b/neo/attachment/types.go
@@ -64,6 +64,7 @@ type ManagerOption struct {
 	MaxSize      string                 `json:"max_size,omitempty" yaml:"max_size,omitempty"`           // Max size of the file, Optional, default is 20M
 	ChunkSize    string                 `json:"chunk_size,omitempty" yaml:"chunk_size,omitempty"`       // Chunk size of the file, Optional, default is 2M
 	AllowedTypes []string               `json:"allowed_types,omitempty" yaml:"allowed_types,omitempty"` // Allowed types of the file, Optional, default is all
+	Gzip         bool                   `json:"gzip,omitempty" yaml:"gzip,omitempty"`                   // Gzip the file, Optional, default is false
 	Driver       string                 `json:"driver,omitempty" yaml:"driver,omitempty"`               // Driver, Optional, default is local
 	Options      map[string]interface{} `json:"options,omitempty" yaml:"options,omitempty"`             // Options, Optional
 }

--- a/widgets/app/app.go
+++ b/widgets/app/app.go
@@ -568,16 +568,19 @@ func processXgen(process *process.Process) interface{} {
 				"max_size":      neo.Neo.UploadSetting.Chat.MaxSize,
 				"chunk_size":    neo.Neo.UploadSetting.Chat.ChunkSize,
 				"allowed_types": neo.Neo.UploadSetting.Chat.AllowedTypes,
+				"gzip":          neo.Neo.UploadSetting.Chat.Gzip,
 			},
 			"assets": map[string]interface{}{
 				"max_size":      neo.Neo.UploadSetting.Assets.MaxSize,
 				"chunk_size":    neo.Neo.UploadSetting.Assets.ChunkSize,
 				"allowed_types": neo.Neo.UploadSetting.Assets.AllowedTypes,
+				"gzip":          neo.Neo.UploadSetting.Assets.Gzip,
 			},
 			"knowledge": map[string]interface{}{
 				"max_size":      neo.Neo.UploadSetting.Knowledge.MaxSize,
 				"chunk_size":    neo.Neo.UploadSetting.Knowledge.ChunkSize,
 				"allowed_types": neo.Neo.UploadSetting.Knowledge.AllowedTypes,
+				"gzip":          neo.Neo.UploadSetting.Knowledge.Gzip,
 			},
 		}
 	}


### PR DESCRIPTION
- Introduced a new Gzip field in the ManagerOption struct to allow optional gzip compression for file uploads.
- Updated the processXgen function to include the gzip setting for chat, assets, and knowledge upload configurations, enhancing flexibility in file handling.