### PR TITLE
Enhance time value handling and improve test assertions

### DIFF
--- a/dsl/io/db.go
+++ b/dsl/io/db.go
@@ -46,6 +46,19 @@ func fmtRow(row map[string]interface{}) map[string]interface{} {
 	if row["built_in"] != nil {
 		row["built_in"] = toBool(row["built_in"])
 	}
+
+	// Convert time values
+	if mtime, ok := row["mtime"]; ok && mtime != nil {
+		if timeStr := toTime(mtime); timeStr != "" {
+			row["mtime"] = timeStr
+		}
+	}
+	if ctime, ok := row["ctime"]; ok && ctime != nil {
+		if timeStr := toTime(ctime); timeStr != "" {
+			row["ctime"] = timeStr
+		}
+	}
+
 	return row
 }
 

--- a/dsl/io/db_test.go
+++ b/dsl/io/db_test.go
@@ -82,7 +82,9 @@ func TestDBList(t *testing.T) {
 	list, err = db.List(tc1.ListOptions(false))
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(list))
-	assert.Equal(t, tc1.ID, list[0].ID)
+	if assert.Greater(t, len(list), 0, "List should not be empty") {
+		assert.Equal(t, tc1.ID, list[0].ID)
+	}
 }
 
 func TestDBUpdate(t *testing.T) {

--- a/dsl/io/utils.go
+++ b/dsl/io/utils.go
@@ -1,5 +1,7 @@
 package io
 
+import "time"
+
 // toBool converts various types to boolean
 func toBool(v interface{}) bool {
 	if v == nil {
@@ -20,4 +22,30 @@ func toBool(v interface{}) bool {
 	default:
 		return false
 	}
+}
+
+// toTime converts various time formats to RFC3339 string
+func toTime(v interface{}) string {
+	if v == nil {
+		return ""
+	}
+
+	switch val := v.(type) {
+	case string:
+		// Try common formats
+		formats := []string{
+			"2006-01-02 15:04:05",       // SQLite format
+			"2006-01-02T15:04:05Z07:00", // RFC3339 format
+			"2006-01-02T15:04:05Z",      // RFC3339 without timezone
+			time.RFC3339,
+		}
+		for _, format := range formats {
+			if t, err := time.Parse(format, val); err == nil {
+				return t.UTC().Format(time.RFC3339) // Convert to UTC and format as RFC3339
+			}
+		}
+	case time.Time:
+		return val.UTC().Format(time.RFC3339) // Convert to UTC and format as RFC3339
+	}
+	return ""
 }


### PR DESCRIPTION
- Added a new toTime function to convert various time formats to RFC3339 strings, ensuring consistent time representation in the data.
- Updated the fmtRow function to utilize the new toTime function for 'mtime' and 'ctime' fields, enhancing data formatting.
- Modified the TestDBList function to include a check for non-empty lists before asserting the ID, improving test robustness.