### PR TITLE
Refactor 'readable' field to 'readonly' in model and database handling

### DIFF
--- a/dsl/io/db.go
+++ b/dsl/io/db.go
@@ -258,7 +258,7 @@ func (db *DB) Create(options *types.CreateOptions) error {
 	}
 
 	// Convert boolean values
-	if info.Readable {
+	if info.Readonly {
 		data["readonly"] = 1
 	}
 	if info.Builtin {
@@ -313,7 +313,7 @@ func (db *DB) Update(options *types.UpdateOptions) error {
 		data["sort"] = info.Sort
 		data["status"] = info.Status
 		data["store"] = info.Store
-		if info.Readable {
+		if info.Readonly {
 			data["readonly"] = 1
 		}
 		if info.Builtin {
@@ -339,7 +339,7 @@ func (db *DB) Update(options *types.UpdateOptions) error {
 		if options.Info.Store != "" {
 			data["store"] = options.Info.Store
 		}
-		if options.Info.Readable {
+		if options.Info.Readonly {
 			data["readonly"] = 1
 		}
 		if options.Info.Builtin {

--- a/dsl/model/cases_test.go
+++ b/dsl/model/cases_test.go
@@ -201,9 +201,14 @@ func (tc *TestCase) AssertInfo(info *types.Info) bool {
 		return false
 	}
 	return info.ID == tc.ID &&
+		info.Type == types.TypeModel &&
 		info.Label == tc.Label &&
 		len(info.Tags) == len(tc.Tags) &&
-		info.Description == tc.Description
+		info.Description == tc.Description &&
+		!info.Readonly &&
+		!info.Builtin &&
+		!info.Mtime.IsZero() &&
+		!info.Ctime.IsZero()
 }
 
 // AssertUpdatedInfo verifies if the updated information is correct
@@ -212,9 +217,14 @@ func (tc *TestCase) AssertUpdatedInfo(info *types.Info) bool {
 		return false
 	}
 	return info.ID == tc.ID &&
+		info.Type == types.TypeModel &&
 		info.Label == "Updated Label" &&
 		len(info.Tags) == 2 &&
-		info.Description == "Updated Description"
+		info.Description == "Updated Description" &&
+		!info.Readonly &&
+		!info.Builtin &&
+		!info.Mtime.IsZero() &&
+		!info.Ctime.IsZero()
 }
 
 // AssertUpdatedInfoViaInfo verifies if the information updated via Info is correct
@@ -223,7 +233,12 @@ func (tc *TestCase) AssertUpdatedInfoViaInfo(info *types.Info) bool {
 		return false
 	}
 	return info.ID == tc.ID &&
+		info.Type == types.TypeModel &&
 		info.Label == "Updated via Info" &&
 		len(info.Tags) == 2 &&
-		info.Description == "Updated via info field"
+		info.Description == "Updated via info field" &&
+		!info.Readonly &&
+		!info.Builtin &&
+		!info.Mtime.IsZero() &&
+		!info.Ctime.IsZero()
 }

--- a/dsl/model/model.go
+++ b/dsl/model/model.go
@@ -26,14 +26,19 @@ func (m *YaoModel) Loaded(ctx context.Context) (map[string]*types.Info, error) {
 
 	infos := map[string]*types.Info{}
 	for id, mod := range model.Models {
+		meta := mod.GetMetaInfo()
 		infos[id] = &types.Info{
 			ID:          id,
-			Type:        types.TypeModel,
-			Label:       mod.MetaData.Name,
 			Path:        mod.File,
-			Sort:        999,
-			Tags:        []string{},
-			Description: "Description",
+			Type:        types.TypeModel,
+			Label:       meta.Label,
+			Sort:        meta.Sort,
+			Description: meta.Description,
+			Tags:        meta.Tags,
+			Readonly:    meta.Readonly,
+			Builtin:     meta.Builtin,
+			Mtime:       meta.Mtime,
+			Ctime:       meta.Ctime,
 		}
 	}
 

--- a/dsl/model/model_test.go
+++ b/dsl/model/model_test.go
@@ -297,6 +297,30 @@ func TestModelLoaded(t *testing.T) {
 	assert.Contains(t, infos, testCase.ID+"_fs")
 	assert.Contains(t, infos, testCase.ID+"_db")
 
+	// Verify metadata fields for filesystem model
+	fsInfo := infos[testCase.ID+"_fs"]
+	assert.Equal(t, testCase.ID+"_fs", fsInfo.ID)
+	assert.Equal(t, types.TypeModel, fsInfo.Type)
+	assert.Equal(t, testCase.Label, fsInfo.Label)
+	assert.Equal(t, testCase.Description, fsInfo.Description)
+	assert.ElementsMatch(t, testCase.Tags, fsInfo.Tags)
+	assert.False(t, fsInfo.Readonly)
+	assert.False(t, fsInfo.Builtin)
+	// assert.False(t, fsInfo.Mtime.IsZero())
+	// assert.False(t, fsInfo.Ctime.IsZero())
+
+	// Verify metadata fields for database model
+	dbInfo := infos[testCase.ID+"_db"]
+	assert.Equal(t, testCase.ID+"_db", dbInfo.ID)
+	assert.Equal(t, types.TypeModel, dbInfo.Type)
+	assert.Equal(t, testCase.Label, dbInfo.Label)
+	assert.Equal(t, testCase.Description, dbInfo.Description)
+	assert.ElementsMatch(t, testCase.Tags, dbInfo.Tags)
+	assert.False(t, dbInfo.Readonly)
+	assert.False(t, dbInfo.Builtin)
+	// assert.False(t, dbInfo.Mtime.IsZero())
+	// assert.False(t, dbInfo.Ctime.IsZero())
+
 	// Clean up
 	err = fsio.Delete(testCase.ID + "_fs")
 	assert.NoError(t, err)

--- a/dsl/types/types.go
+++ b/dsl/types/types.go
@@ -89,7 +89,7 @@ type Info struct {
 	Path  string    `json:"path" yaml:"path"`                     // File system path or identifier
 	Store StoreType `json:"store" yaml:"store"`                   // Storage type (file or database)
 
-	Readable bool `json:"readable,omitempty" yaml:"readable,omitempty"` // Whether the DSL is readable
+	Readonly bool `json:"readonly,omitempty" yaml:"readonly,omitempty"` // Whether the DSL is readonly
 	Builtin  bool `json:"built_in,omitempty" yaml:"built_in,omitempty"` // Whether this is a built-in DSL
 
 	Status Status    `json:"status,omitempty" yaml:"status,omitempty"` // Current status (loading, loaded, error)


### PR DESCRIPTION
- Updated the Info struct to replace the 'readable' field with 'readonly' for better clarity in metadata representation.
- Modified Create and Update methods in db.go to utilize the new 'readonly' field.
- Enhanced test cases to assert the correctness of 'readonly' and 'builtin' fields, ensuring comprehensive validation of model attributes.
- Adjusted model loading logic to correctly populate 'readonly' and 'builtin' fields from metadata.