### PR TITLE
Set default prefix in Prepare function for test environment

### DIFF
--- a/test/utils.go
+++ b/test/utils.go
@@ -187,6 +187,11 @@ func Prepare(t *testing.T, cfg config.Config, rootEnv ...string) {
 		t.Fatal(err)
 	}
 
+	// Set default prefix
+	if share.App.Prefix == "" {
+		share.App.Prefix = "yao_"
+	}
+
 	utils.Init()
 	dbconnect(t, cfg)
 	load(t, cfg)


### PR DESCRIPTION
- Added logic to set a default prefix of "yao_" for the application if none is provided, ensuring consistent naming conventions in the test setup.