### PR TITLE
Deprecate studio API functions and comment out implementation details

### DIFF
--- a/studio/studio.go
+++ b/studio/studio.go
@@ -2,20 +2,9 @@ package studio
 
 import (
 	"fmt"
-	"net"
-	"net/http"
-	"os"
-	"os/signal"
-	"syscall"
 
-	"github.com/gin-gonic/gin"
-	"github.com/yaoapp/gou/application"
 	"github.com/yaoapp/gou/fs"
-	"github.com/yaoapp/gou/fs/dsl"
-	v8 "github.com/yaoapp/gou/runtime/v8"
-	"github.com/yaoapp/kun/log"
 	"github.com/yaoapp/yao/config"
-	"github.com/yaoapp/yao/share"
 )
 
 var shutdownSignal = make(chan bool, 1)
@@ -31,59 +20,59 @@ type cfunc struct {
 func Start(cfg config.Config) (err error) {
 	return fmt.Errorf("studio is deprecated")
 
-	// recive interrupt signal
-	interrupt := make(chan os.Signal, 1)
-	signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
+	// // recive interrupt signal
+	// interrupt := make(chan os.Signal, 1)
+	// signal.Notify(interrupt, os.Interrupt, syscall.SIGTERM, syscall.SIGQUIT)
 
-	errCh := make(chan error, 1)
+	// errCh := make(chan error, 1)
 
-	// Set router
-	router := gin.New()
-	setRouter(router)
+	// // Set router
+	// router := gin.New()
+	// setRouter(router)
 
-	// Server setting
-	addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Studio.Port)
-	srv := &http.Server{
-		Addr:    addr,
-		Handler: router,
-	}
+	// // Server setting
+	// addr := fmt.Sprintf("%s:%d", cfg.Host, cfg.Studio.Port)
+	// srv := &http.Server{
+	// 	Addr:    addr,
+	// 	Handler: router,
+	// }
 
-	// Listen
-	l, err := net.Listen("tcp", addr)
-	if err != nil {
-		return err
-	}
+	// // Listen
+	// l, err := net.Listen("tcp", addr)
+	// if err != nil {
+	// 	return err
+	// }
 
-	defer func() {
-		log.Info("[Studio] %s Close Serve", addr)
-		err = srv.Close()
-		if err != nil {
-			log.Error("[Studio] Close Serve Error (%v)", err)
-		}
-	}()
+	// defer func() {
+	// 	log.Info("[Studio] %s Close Serve", addr)
+	// 	err = srv.Close()
+	// 	if err != nil {
+	// 		log.Error("[Studio] Close Serve Error (%v)", err)
+	// 	}
+	// }()
 
-	// start serve
-	go func() {
-		log.Info("[Studio] Starting: %s", addr)
-		if err := srv.Serve(l); err != nil && err != http.ErrServerClosed {
-			errCh <- err
-		}
-	}()
+	// // start serve
+	// go func() {
+	// 	log.Info("[Studio] Starting: %s", addr)
+	// 	if err := srv.Serve(l); err != nil && err != http.ErrServerClosed {
+	// 		errCh <- err
+	// 	}
+	// }()
 
-	select {
+	// select {
 
-	case <-shutdownSignal:
-		log.Info("[Studio] %s Exit (Manual)", addr)
-		return err
+	// case <-shutdownSignal:
+	// 	log.Info("[Studio] %s Exit (Manual)", addr)
+	// 	return err
 
-	case <-interrupt:
-		log.Info("[Studio] %s Exit (Interrupt) ", addr)
-		return err
+	// case <-interrupt:
+	// 	log.Info("[Studio] %s Exit (Interrupt) ", addr)
+	// 	return err
 
-	case err := <-errCh:
-		log.Error("[Studio] %s Error (%v)", addr, err)
-		return err
-	}
+	// case err := <-errCh:
+	// 	log.Error("[Studio] %s Error (%v)", addr, err)
+	// 	return err
+	// }
 }
 
 // Stop stop the studio api server
@@ -95,28 +84,28 @@ func Stop() {
 func Load(cfg config.Config) error {
 	return fmt.Errorf("studio is deprecated")
 
-	err := loadDSL(cfg)
-	if err != nil {
-		return err
-	}
-	return loadScripts()
+	// err := loadDSL(cfg)
+	// if err != nil {
+	// 	return err
+	// }
+	// return loadScripts()
 }
 
 func loadDSL(cfg config.Config) error {
 	return fmt.Errorf("studio is deprecated")
-	dslDenyList := []string{cfg.DataRoot}
-	dfs = dsl.New(cfg.AppSource).DenyAbs(dslDenyList...)
-	return nil
+	// dslDenyList := []string{cfg.DataRoot}
+	// dfs = dsl.New(cfg.AppSource).DenyAbs(dslDenyList...)
+	// return nil
 }
 
 func loadScripts() error {
 	return fmt.Errorf("studio is deprecated")
-	exts := []string{"*.js"}
-	return application.App.Walk("studio", func(root, file string, isdir bool) error {
-		if isdir {
-			return nil
-		}
-		_, err := v8.LoadRoot(file, share.ID(root, file))
-		return err
-	}, exts...)
+	// exts := []string{"*.js"}
+	// return application.App.Walk("studio", func(root, file string, isdir bool) error {
+	// 	if isdir {
+	// 		return nil
+	// 	}
+	// 	_, err := v8.LoadRoot(file, share.ID(root, file))
+	// 	return err
+	// }, exts...)
 }


### PR DESCRIPTION
- Marked the studio API functions (Start, Load, loadDSL, loadScripts) as deprecated, returning an error message to indicate their status.
- Commented out the implementation details of these functions to prevent execution of deprecated functionality, ensuring clarity in the codebase.