### PR TITLE
Remove deprecated test files and refactor OAuth response handling

### DIFF
--- a/openapi/kb/collection.go
+++ b/openapi/kb/collection.go
@@ -1,9 +1,11 @@
 package kb
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/yaoapp/gou/graphrag/types"
 	"github.com/yaoapp/yao/kb"
 )
 
@@ -11,8 +13,44 @@ import (
 
 // CreateCollection creates a new collection
 func CreateCollection(c *gin.Context) {
-	// TODO: Implement create collection logic
-	c.JSON(http.StatusCreated, gin.H{"message": "Collection created"})
+	var req CreateCollectionRequest
+
+	// Parse and bind JSON request
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request format: " + err.Error()})
+		return
+	}
+
+	// Validate request parameters
+	if err := validateCreateCollectionRequest(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Check if kb.Instance is available
+	if kb.Instance == nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Knowledge base not initialized"})
+		return
+	}
+
+	// Create CollectionConfig
+	collectionConfig := types.CollectionConfig{
+		ID:       req.ID,
+		Metadata: req.Metadata,
+		Config:   req.Config,
+	}
+
+	// Call the actual CreateCollection method
+	collectionID, err := kb.Instance.CreateCollection(c.Request.Context(), collectionConfig)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create collection: " + err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusCreated, gin.H{
+		"message":       "Collection created successfully",
+		"collection_id": collectionID,
+	})
 }
 
 // RemoveCollection removes an existing collection
@@ -35,4 +73,29 @@ func GetCollections(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, collections)
+}
+
+// CreateCollectionRequest represents the request structure for creating a collection
+type CreateCollectionRequest struct {
+	ID       string                         `json:"id" binding:"required"`
+	Metadata map[string]interface{}         `json:"metadata"`
+	Config   *types.CreateCollectionOptions `json:"config" binding:"required"`
+}
+
+// validateCreateCollectionRequest validates the incoming request for creating a collection
+func validateCreateCollectionRequest(req *CreateCollectionRequest) error {
+	if req.ID == "" {
+		return fmt.Errorf("id is required")
+	}
+
+	if req.Config == nil {
+		return fmt.Errorf("config is required")
+	}
+
+	// Validate CreateCollectionOptions
+	if err := req.Config.Validate(); err != nil {
+		return fmt.Errorf("invalid config: %w", err)
+	}
+
+	return nil
 }

--- a/openapi/response/response.go
+++ b/openapi/response/response.go
@@ -1,4 +1,4 @@
-package openapi
+package response
 
 import (
 	"net/http"
@@ -147,7 +147,7 @@ const (
 
 // setOAuthSecurityHeaders sets standard OAuth 2.0/2.1 security headers
 // These headers are required by OAuth 2.1 specification for enhanced security
-func (openapi *OpenAPI) setOAuthSecurityHeaders(c *gin.Context) {
+func SetOAuthSecurityHeaders(c *gin.Context) {
 	c.Header("Cache-Control", "no-store")
 	c.Header("Pragma", "no-cache")
 	c.Header("X-Content-Type-Options", "nosniff")
@@ -156,30 +156,30 @@ func (openapi *OpenAPI) setOAuthSecurityHeaders(c *gin.Context) {
 }
 
 // setJSONContentType sets JSON content type header for OAuth responses
-func (openapi *OpenAPI) setJSONContentType(c *gin.Context) {
+func SetJSONContentType(c *gin.Context) {
 	c.Header("Content-Type", "application/json")
 }
 
-// respondWithSuccess sends a successful response (no wrapper, direct data)
-func (openapi *OpenAPI) respondWithSuccess(c *gin.Context, statusCode int, data interface{}) {
-	openapi.setJSONContentType(c)
+// RespondWithSuccess sends a successful response (no wrapper, direct data)
+func RespondWithSuccess(c *gin.Context, statusCode int, data interface{}) {
+	SetJSONContentType(c)
 	c.JSON(statusCode, data)
 }
 
-// respondWithError sends an error response (no wrapper, direct error)
-func (openapi *OpenAPI) respondWithError(c *gin.Context, statusCode int, err *ErrorResponse) {
-	openapi.setJSONContentType(c)
+// RespondWithError sends an error response (no wrapper, direct error)
+func RespondWithError(c *gin.Context, statusCode int, err *ErrorResponse) {
+	SetJSONContentType(c)
 
 	// Add WWW-Authenticate header for 401 responses
 	if statusCode == StatusUnauthorized {
-		openapi.addWWWAuthenticateHeader(c, err)
+		AddWWWAuthenticateHeader(c, err)
 	}
 
 	c.JSON(statusCode, err)
 }
 
-// respondWithAuthorizationError sends an authorization endpoint error via redirect
-func (openapi *OpenAPI) respondWithAuthorizationError(c *gin.Context, redirectURI string, err *ErrorResponse, state string) {
+// RespondWithAuthorizationError sends an authorization endpoint error via redirect
+func RespondWithAuthorizationError(c *gin.Context, redirectURI string, err *ErrorResponse, state string) {
 	// Build error redirect URL
 	redirectURL := redirectURI
 	if redirectURL != "" {
@@ -204,11 +204,11 @@ func (openapi *OpenAPI) respondWithAuthorizationError(c *gin.Context, redirectUR
 	}
 
 	// Fallback to JSON error response if no redirect URI
-	openapi.respondWithError(c, StatusBadRequest, err)
+	RespondWithError(c, StatusBadRequest, err)
 }
 
-// addWWWAuthenticateHeader adds appropriate WWW-Authenticate header
-func (openapi *OpenAPI) addWWWAuthenticateHeader(c *gin.Context, err *ErrorResponse) {
+// AddWWWAuthenticateHeader adds appropriate WWW-Authenticate header
+func AddWWWAuthenticateHeader(c *gin.Context, err *ErrorResponse) {
 	challenge := &WWWAuthenticateChallenge{
 		Scheme: types.WWWAuthenticateSchemeBearer,
 		Realm:  "OAuth",
@@ -238,21 +238,21 @@ func (openapi *OpenAPI) addWWWAuthenticateHeader(c *gin.Context, err *ErrorRespo
 	c.Header("WWW-Authenticate", headerValue)
 }
 
-// respondWithSecureSuccess sends a successful response with OAuth security headers (for sensitive endpoints)
-func (openapi *OpenAPI) respondWithSecureSuccess(c *gin.Context, statusCode int, data interface{}) {
-	openapi.setOAuthSecurityHeaders(c)
-	openapi.setJSONContentType(c)
+// RespondWithSecureSuccess sends a successful response with OAuth security headers (for sensitive endpoints)
+func RespondWithSecureSuccess(c *gin.Context, statusCode int, data interface{}) {
+	SetOAuthSecurityHeaders(c)
+	SetJSONContentType(c)
 	c.JSON(statusCode, data)
 }
 
-// respondWithSecureError sends an error response with OAuth security headers (for sensitive endpoints)
-func (openapi *OpenAPI) respondWithSecureError(c *gin.Context, statusCode int, err *ErrorResponse) {
-	openapi.setOAuthSecurityHeaders(c)
-	openapi.setJSONContentType(c)
+// RespondWithSecureError sends an error response with OAuth security headers (for sensitive endpoints)
+func RespondWithSecureError(c *gin.Context, statusCode int, err *ErrorResponse) {
+	SetOAuthSecurityHeaders(c)
+	SetJSONContentType(c)
 
 	// Add WWW-Authenticate header for 401 responses
 	if statusCode == StatusUnauthorized {
-		openapi.addWWWAuthenticateHeader(c, err)
+		AddWWWAuthenticateHeader(c, err)
 	}
 
 	c.JSON(statusCode, err)

--- a/openapi/tests/dsl/dsl_test.go
+++ b/openapi/tests/dsl/dsl_test.go
@@ -1,4 +1,4 @@
-package openapi
+package openapi_test
 
 import (
 	"bytes"
@@ -10,23 +10,25 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/yaoapp/yao/dsl/types"
+	"github.com/yaoapp/yao/openapi"
+	"github.com/yaoapp/yao/openapi/tests/testutils"
 )
 
 // TestDSLCreate tests the DSL creation endpoint
 func TestDSLCreate(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	// Get base URL from server config
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
 	// Register test client and get token
-	client := RegisterTestClient(t, "DSL Create Test Client", []string{"https://localhost/callback"})
-	defer CleanupTestClient(t, client.ClientID)
-	tokenInfo := ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
+	client := testutils.RegisterTestClient(t, "DSL Create Test Client", []string{"https://localhost/callback"})
+	defer testutils.CleanupTestClient(t, client.ClientID)
+	tokenInfo := testutils.ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
 
 	// Generate unique test ID
 	testID := fmt.Sprintf("test_model_%d", time.Now().UnixNano())
@@ -51,7 +53,7 @@ func TestDSLCreate(t *testing.T) {
 
 	for _, store := range stores {
 		t.Run(fmt.Sprintf("CreateModel_%s", store), func(t *testing.T) {
-			// Prepare request body
+			// testutils.Prepare request body
 			createData := map[string]interface{}{
 				"id":     testID + "_" + store,
 				"source": modelSource,
@@ -89,17 +91,17 @@ func TestDSLCreate(t *testing.T) {
 
 // TestDSLInspect tests the DSL inspection endpoint
 func TestDSLInspect(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
-	client := RegisterTestClient(t, "DSL Inspect Test Client", []string{"https://localhost/callback"})
-	defer CleanupTestClient(t, client.ClientID)
-	tokenInfo := ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
+	client := testutils.RegisterTestClient(t, "DSL Inspect Test Client", []string{"https://localhost/callback"})
+	defer testutils.CleanupTestClient(t, client.ClientID)
+	tokenInfo := testutils.ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
 
 	testID := fmt.Sprintf("test_inspect_%d", time.Now().UnixNano())
 	modelSource := fmt.Sprintf(`{
@@ -162,17 +164,17 @@ func TestDSLInspect(t *testing.T) {
 
 // TestDSLSource tests the DSL source retrieval endpoint
 func TestDSLSource(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
-	client := RegisterTestClient(t, "DSL Source Test Client", []string{"https://localhost/callback"})
-	defer CleanupTestClient(t, client.ClientID)
-	tokenInfo := ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
+	client := testutils.RegisterTestClient(t, "DSL Source Test Client", []string{"https://localhost/callback"})
+	defer testutils.CleanupTestClient(t, client.ClientID)
+	tokenInfo := testutils.ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
 
 	testID := fmt.Sprintf("test_source_%d", time.Now().UnixNano())
 	modelSource := fmt.Sprintf(`{
@@ -230,17 +232,17 @@ func TestDSLSource(t *testing.T) {
 
 // TestDSLList tests the DSL listing endpoint
 func TestDSLList(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
-	client := RegisterTestClient(t, "DSL List Test Client", []string{"https://localhost/callback"})
-	defer CleanupTestClient(t, client.ClientID)
-	tokenInfo := ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
+	client := testutils.RegisterTestClient(t, "DSL List Test Client", []string{"https://localhost/callback"})
+	defer testutils.CleanupTestClient(t, client.ClientID)
+	tokenInfo := testutils.ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
 
 	// Create multiple test models
 	testTag := fmt.Sprintf("test_list_%d", time.Now().UnixNano())
@@ -317,17 +319,17 @@ func TestDSLList(t *testing.T) {
 
 // TestDSLUpdate tests the DSL update endpoint
 func TestDSLUpdate(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
-	client := RegisterTestClient(t, "DSL Update Test Client", []string{"https://localhost/callback"})
-	defer CleanupTestClient(t, client.ClientID)
-	tokenInfo := ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
+	client := testutils.RegisterTestClient(t, "DSL Update Test Client", []string{"https://localhost/callback"})
+	defer testutils.CleanupTestClient(t, client.ClientID)
+	tokenInfo := testutils.ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
 
 	testID := fmt.Sprintf("test_update_%d", time.Now().UnixNano())
 
@@ -424,17 +426,17 @@ func TestDSLUpdate(t *testing.T) {
 
 // TestDSLExists tests the DSL existence check endpoint
 func TestDSLExists(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
-	client := RegisterTestClient(t, "DSL Exists Test Client", []string{"https://localhost/callback"})
-	defer CleanupTestClient(t, client.ClientID)
-	tokenInfo := ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
+	client := testutils.RegisterTestClient(t, "DSL Exists Test Client", []string{"https://localhost/callback"})
+	defer testutils.CleanupTestClient(t, client.ClientID)
+	tokenInfo := testutils.ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
 
 	testID := fmt.Sprintf("test_exists_%d", time.Now().UnixNano())
 	nonExistentID := fmt.Sprintf("non_existent_%d", time.Now().UnixNano())
@@ -500,17 +502,17 @@ func TestDSLExists(t *testing.T) {
 
 // TestDSLDelete tests the DSL deletion endpoint
 func TestDSLDelete(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
-	client := RegisterTestClient(t, "DSL Delete Test Client", []string{"https://localhost/callback"})
-	defer CleanupTestClient(t, client.ClientID)
-	tokenInfo := ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
+	client := testutils.RegisterTestClient(t, "DSL Delete Test Client", []string{"https://localhost/callback"})
+	defer testutils.CleanupTestClient(t, client.ClientID)
+	tokenInfo := testutils.ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
 
 	testID := fmt.Sprintf("test_delete_%d", time.Now().UnixNano())
 
@@ -576,17 +578,17 @@ func TestDSLDelete(t *testing.T) {
 
 // TestDSLValidate tests the DSL validation endpoint
 func TestDSLValidate(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
-	client := RegisterTestClient(t, "DSL Validate Test Client", []string{"https://localhost/callback"})
-	defer CleanupTestClient(t, client.ClientID)
-	tokenInfo := ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
+	client := testutils.RegisterTestClient(t, "DSL Validate Test Client", []string{"https://localhost/callback"})
+	defer testutils.CleanupTestClient(t, client.ClientID)
+	tokenInfo := testutils.ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
 
 	tests := []struct {
 		name        string
@@ -662,12 +664,12 @@ func TestDSLValidate(t *testing.T) {
 
 // TestDSLUnauthorized tests that endpoints return 401 when not authenticated
 func TestDSLUnauthorized(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
 	endpoints := []struct {

--- a/openapi/tests/hello/hello_test.go
+++ b/openapi/tests/hello/hello_test.go
@@ -1,4 +1,4 @@
-package openapi
+package openapi_test
 
 import (
 	"encoding/json"
@@ -6,17 +6,19 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/yaoapp/yao/openapi"
+	"github.com/yaoapp/yao/openapi/tests/testutils"
 	"github.com/yaoapp/yao/share"
 )
 
 func TestHelloWorldPublic(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	// Get base URL from server config
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
 	tests := []struct {
@@ -79,21 +81,21 @@ func TestHelloWorldPublic(t *testing.T) {
 }
 
 func TestHelloWorldProtected(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	// Get base URL from server config
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
 	// Register a test client for authentication
-	client := RegisterTestClient(t, "Hello World Protected Test Client", []string{"https://localhost/callback"})
-	defer CleanupTestClient(t, client.ClientID)
+	client := testutils.RegisterTestClient(t, "Hello World Protected Test Client", []string{"https://localhost/callback"})
+	defer testutils.CleanupTestClient(t, client.ClientID)
 
 	// Obtain access token for authentication
-	tokenInfo := ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
+	tokenInfo := testutils.ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile")
 
 	tests := []struct {
 		name   string
@@ -164,13 +166,13 @@ func TestHelloWorldProtected(t *testing.T) {
 }
 
 func TestHelloWorldProtectedUnauthorized(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	// Get base URL from server config
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
 	tests := []struct {

--- a/openapi/tests/oauth/oauth_test.go
+++ b/openapi/tests/oauth/oauth_test.go
@@ -1,4 +1,4 @@
-package openapi
+package openapi_test
 
 import (
 	"bytes"
@@ -9,32 +9,34 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/yaoapp/yao/openapi"
 	"github.com/yaoapp/yao/openapi/oauth/types"
+	"github.com/yaoapp/yao/openapi/tests/testutils"
 )
 
 func TestOAuthRegister(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
-	// Debug: Check if Server is properly initialized
-	if Server == nil {
-		t.Fatal("OpenAPI Server is nil")
+	// Debug: Check if openapi.Server is properly initialized
+	if openapi.Server == nil {
+		t.Fatal("OpenAPI openapi.Server is nil")
 	}
 
-	if Server.Config == nil {
-		t.Fatal("OpenAPI Server.Config is nil")
+	if openapi.Server.Config == nil {
+		t.Fatal("OpenAPI openapi.Server.Config is nil")
 	}
 
-	if Server.OAuth == nil {
-		t.Fatal("OpenAPI Server.OAuth is nil")
+	if openapi.Server.OAuth == nil {
+		t.Fatal("OpenAPI openapi.Server.OAuth is nil")
 	}
 
-	t.Logf("Server initialized with BaseURL: %s", Server.Config.BaseURL)
+	t.Logf("openapi.Server initialized with BaseURL: %s", openapi.Server.Config.BaseURL)
 
 	// Get base URL from server config
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
 	endpoint := serverURL + baseURL + "/oauth/register"
@@ -108,24 +110,24 @@ func TestOAuthRegister(t *testing.T) {
 			assert.Equal(t, req.RedirectURIs, response.DynamicClientRegistrationRequest.RedirectURIs)
 
 			// Verify that default values were applied when not specified in request
-			assert.NotEmpty(t, response.DynamicClientRegistrationRequest.GrantTypes, "Server should apply default grant types")
-			assert.NotEmpty(t, response.DynamicClientRegistrationRequest.ResponseTypes, "Server should apply default response types")
-			assert.Equal(t, "web", response.DynamicClientRegistrationRequest.ApplicationType, "Server should apply default application type")
-			assert.Equal(t, "client_secret_basic", response.DynamicClientRegistrationRequest.TokenEndpointAuthMethod, "Server should apply default auth method")
+			assert.NotEmpty(t, response.DynamicClientRegistrationRequest.GrantTypes, "openapi.Server should apply default grant types")
+			assert.NotEmpty(t, response.DynamicClientRegistrationRequest.ResponseTypes, "openapi.Server should apply default response types")
+			assert.Equal(t, "web", response.DynamicClientRegistrationRequest.ApplicationType, "openapi.Server should apply default application type")
+			assert.Equal(t, "client_secret_basic", response.DynamicClientRegistrationRequest.TokenEndpointAuthMethod, "openapi.Server should apply default auth method")
 		}
 	})
 }
 
 func TestOAuthAuthorize(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
 	// Register a test client for realistic testing
-	testClient := RegisterTestClient(t, "OAuth Test Client", []string{"http://localhost/callback"})
-	defer CleanupTestClient(t, testClient.ClientID)
+	testClient := testutils.RegisterTestClient(t, "OAuth Test Client", []string{"http://localhost/callback"})
+	defer testutils.CleanupTestClient(t, testClient.ClientID)
 
-	// Prepare test data
-	endpoint := serverURL + Server.Config.BaseURL + "/oauth/authorize"
+	// testutils.Prepare test data
+	endpoint := serverURL + openapi.Server.Config.BaseURL + "/oauth/authorize"
 	t.Logf("Testing authorize endpoint: %s", endpoint)
 
 	t.Run("Valid Authorization Request", func(t *testing.T) {
@@ -324,28 +326,28 @@ func TestOAuthAuthorize(t *testing.T) {
 }
 
 func TestOAuthJWKS(t *testing.T) {
-	serverURL := Prepare(t)
-	defer Clean()
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
 
-	// Debug: Check if Server is properly initialized
-	if Server == nil {
-		t.Fatal("OpenAPI Server is nil")
+	// Debug: Check if openapi.Server is properly initialized
+	if openapi.Server == nil {
+		t.Fatal("OpenAPI openapi.Server is nil")
 	}
 
-	if Server.Config == nil {
-		t.Fatal("OpenAPI Server.Config is nil")
+	if openapi.Server.Config == nil {
+		t.Fatal("OpenAPI openapi.Server.Config is nil")
 	}
 
-	if Server.OAuth == nil {
-		t.Fatal("OpenAPI Server.OAuth is nil")
+	if openapi.Server.OAuth == nil {
+		t.Fatal("OpenAPI openapi.Server.OAuth is nil")
 	}
 
-	t.Logf("Server initialized with BaseURL: %s", Server.Config.BaseURL)
+	t.Logf("openapi.Server initialized with BaseURL: %s", openapi.Server.Config.BaseURL)
 
 	// Get base URL from server config
 	baseURL := ""
-	if Server != nil && Server.Config != nil {
-		baseURL = Server.Config.BaseURL
+	if openapi.Server != nil && openapi.Server.Config != nil {
+		baseURL = openapi.Server.Config.BaseURL
 	}
 
 	endpoint := serverURL + baseURL + "/oauth/jwks"

--- a/openapi/tests/openapi_test.go
+++ b/openapi/tests/openapi_test.go
@@ -1,0 +1,41 @@
+package openapi_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/yaoapp/yao/openapi"
+	"github.com/yaoapp/yao/openapi/tests/testutils"
+)
+
+func TestLoad(t *testing.T) {
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
+
+	assert.NotNil(t, openapi.Server)
+	assert.NotEmpty(t, serverURL)
+	assert.Contains(t, serverURL, "http://127.0.0.1:")
+}
+
+func TestObtainAccessToken(t *testing.T) {
+	serverURL := testutils.Prepare(t)
+	defer testutils.Clean()
+
+	// Register a test client
+	client := testutils.RegisterTestClient(t, "Token Utility Test Client", []string{"https://localhost/callback"})
+	defer testutils.CleanupTestClient(t, client.ClientID)
+
+	// Test the ObtainAccessToken utility function
+	tokenInfo := testutils.ObtainAccessToken(t, serverURL, client.ClientID, client.ClientSecret, "https://localhost/callback", "openid profile email")
+
+	// Verify token information
+	assert.NotEmpty(t, tokenInfo.AccessToken, "Access token should not be empty")
+	assert.NotEmpty(t, tokenInfo.RefreshToken, "Refresh token should not be empty")
+	assert.Equal(t, "Bearer", tokenInfo.TokenType, "Token type should be Bearer")
+	assert.Greater(t, tokenInfo.ExpiresIn, 0, "ExpiresIn should be greater than 0")
+	assert.Equal(t, client.ClientID, tokenInfo.ClientID, "Client ID should match")
+	// Note: Scope might be empty in token response, which is valid
+
+	t.Logf("Successfully obtained token: AccessToken=%s, TokenType=%s, ExpiresIn=%d, Scope=%s",
+		tokenInfo.AccessToken, tokenInfo.TokenType, tokenInfo.ExpiresIn, tokenInfo.Scope)
+}


### PR DESCRIPTION
- Deleted obsolete test files for various OpenAPI components, including config_test.go, dsl_test.go, hello_test.go, oauth_test.go, oauth_token_test.go, and openapi_test.go, to streamline the codebase.
- Refactored OAuth response handling by integrating response methods from the response package, ensuring consistent error and success responses across OAuth endpoints.
- Enhanced error handling and response structure for improved clarity and maintainability, aligning with best practices for API responses.