### PR TITLE
Implement LocalPath functionality for attachment management

### DIFF
--- a/attachment/manager.go
+++ b/attachment/manager.go
@@ -215,6 +215,18 @@ func New(option ManagerOption) (*Manager, error) {
 	return manager, nil
 }
 
+// LocalPath gets the local path of the file
+func (manager Manager) LocalPath(ctx context.Context, fileID string) (string, string, error) {
+	// Get the real storage path from database
+	storagePath, err := manager.getStoragePathFromDatabase(ctx, fileID)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Call the storage implementation
+	return manager.storage.LocalPath(ctx, storagePath)
+}
+
 // Upload uploads a file, Content-Sync must be true for chunked upload
 func (manager Manager) Upload(ctx context.Context, fileheader *FileHeader, reader io.Reader, option UploadOption) (*File, error) {
 

--- a/attachment/types.go
+++ b/attachment/types.go
@@ -43,6 +43,9 @@ type FileManager interface {
 
 	// Delete deletes a file
 	Delete(ctx context.Context, fileID string) error
+
+	// LocalPath gets the local path of the file
+	LocalPath(ctx context.Context, fileID string) (string, string, error)
 }
 
 // File the file
@@ -103,6 +106,7 @@ type Storage interface {
 	URL(ctx context.Context, path string) string
 	Exists(ctx context.Context, path string) bool
 	Delete(ctx context.Context, path string) error
+	LocalPath(ctx context.Context, path string) (string, string, error) // Returns absolute path and content type
 }
 
 // ManagerOption the manager option

--- a/openapi/kb/utils.go
+++ b/openapi/kb/utils.go
@@ -91,7 +91,8 @@ type BaseUpsertRequest struct {
 // AddFileRequest represents the request for AddFile API
 type AddFileRequest struct {
 	BaseUpsertRequest
-	FileID string `json:"file_id" binding:"required"`
+	FileID   string `json:"file_id" binding:"required"`
+	Uploader string `json:"uploader,omitempty"` // The name of the uploader, e.g. "s3", "local", "webdav", etc.
 }
 
 // AddTextRequest represents the request for AddText API


### PR DESCRIPTION
- Added LocalPath method to the Manager and Storage interfaces to retrieve the absolute path and content type of files.
- Enhanced local and S3 storage implementations to support LocalPath, including handling gzipped files and content type detection.
- Introduced comprehensive tests for LocalPath functionality, covering various file types, non-existent files, and gzipped content.
- Updated AddFile API to utilize LocalPath for retrieving file information, improving error handling and response consistency.