### PR TITLE
Implement global configuration for PDF and FFmpeg in converters

### DIFF
--- a/kb/kb.go
+++ b/kb/kb.go
@@ -50,6 +50,10 @@ func Load(appConfig config.Config) (*KnowledgeBase, error) {
 		return nil, err
 	}
 
+	// Set global configurations for providers to use
+	kbtypes.SetGlobalPDF(config.PDF)
+	kbtypes.SetGlobalFFmpeg(config.FFmpeg)
+
 	// Create the GraphRag config
 	graphRagConfig, err := config.GraphRagConfig()
 	if err != nil {

--- a/kb/providers/converters/ocr.go
+++ b/kb/providers/converters/ocr.go
@@ -32,7 +32,26 @@ func (ocr *OCR) Make(option *kbtypes.ProviderOption) (types.Converter, error) {
 		PDFQuality:     90,                     // Default JPEG quality
 	}
 
-	// Extract values from Properties map
+	// Use global PDF configuration as defaults if available
+	if globalPDF := kbtypes.GetGlobalPDF(); globalPDF != nil {
+		// Map PDF configuration to OCR options
+		if globalPDF.ConvertTool != "" {
+			switch globalPDF.ConvertTool {
+			case "pdftoppm":
+				ocrOption.PDFTool = pdf.ToolPdftoppm
+			case "mutool":
+				ocrOption.PDFTool = pdf.ToolMutool
+			case "imagemagick", "convert":
+				ocrOption.PDFTool = pdf.ToolImageMagick
+			}
+		}
+
+		if globalPDF.ToolPath != "" {
+			ocrOption.PDFToolPath = globalPDF.ToolPath
+		}
+	}
+
+	// Extract values from Properties map to override defaults
 	if option != nil && option.Properties != nil {
 		if mode, ok := option.Properties["mode"]; ok {
 			if modeStr, ok := mode.(string); ok {

--- a/kb/types/types.go
+++ b/kb/types/types.go
@@ -24,6 +24,34 @@ type Features struct {
 	SegmentScoring   bool // Segment scoring system
 }
 
+// Global shared configuration variables
+var (
+	// GlobalPDF holds the global PDF configuration
+	GlobalPDF *PDFConfig
+	// GlobalFFmpeg holds the global FFmpeg configuration
+	GlobalFFmpeg *FFmpegConfig
+)
+
+// SetGlobalPDF sets the global PDF configuration
+func SetGlobalPDF(config *PDFConfig) {
+	GlobalPDF = config
+}
+
+// SetGlobalFFmpeg sets the global FFmpeg configuration
+func SetGlobalFFmpeg(config *FFmpegConfig) {
+	GlobalFFmpeg = config
+}
+
+// GetGlobalPDF returns the global PDF configuration
+func GetGlobalPDF() *PDFConfig {
+	return GlobalPDF
+}
+
+// GetGlobalFFmpeg returns the global FFmpeg configuration
+func GetGlobalFFmpeg() *FFmpegConfig {
+	return GlobalFFmpeg
+}
+
 // Config is the configuration for the Knowledge Base
 type Config struct {
 	// Vector Database configuration (Required)


### PR DESCRIPTION
- Added global configuration support for PDF and FFmpeg in the Knowledge Base, allowing converters to utilize default settings.
- Introduced functions to set and get global configurations for PDF and FFmpeg, enhancing flexibility in converter options.
- Updated OCR and Video converters to leverage global settings, with tests ensuring proper functionality and overrides.
- Enhanced test cases to validate the use of global configurations and property overrides, improving test coverage and reliability.