### PR TITLE
Add response_mode support for OAuth provider in Signin API

### DIFF
--- a/openapi/signin/api.go
+++ b/openapi/signin/api.go
@@ -150,6 +150,11 @@ func getOAuthAuthorizationURL(c *gin.Context) {
 		params.Add("scope", "openid profile email")
 	}
 
+	// Add response_mode if specified (required for Apple with name/email scopes)
+	if provider.ResponseMode != "" {
+		params.Add("response_mode", provider.ResponseMode)
+	}
+
 	authorizationURL := fmt.Sprintf("%s?%s", provider.Endpoints.Authorization, params.Encode())
 
 	// Return the authorization URL and state

--- a/openapi/signin/signin.go
+++ b/openapi/signin/signin.go
@@ -94,6 +94,7 @@ type Provider struct {
 	ClientSecret          string            `json:"client_secret,omitempty"`
 	ClientSecretGenerator *SecretGenerator  `json:"client_secret_generator,omitempty"`
 	Scopes                []string          `json:"scopes,omitempty"`
+	ResponseMode          string            `json:"response_mode,omitempty"`
 	Endpoints             *Endpoints        `json:"endpoints,omitempty"`
 	Mapping               map[string]string `json:"mapping,omitempty"`
 }


### PR DESCRIPTION
- Introduced a new ResponseMode field in the Provider struct to accommodate additional OAuth provider requirements.
- Updated the getOAuthAuthorizationURL function to include response_mode in the authorization URL when specified, enhancing compatibility with providers like Apple that require this parameter.