### PR TITLE
Add scope field to dynamic client registration tests

### DIFF
--- a/openapi/oauth/client_test.go
+++ b/openapi/oauth/client_test.go
@@ -356,6 +356,7 @@ func TestDynamicClientRegistration(t *testing.T) {
 		request := &types.DynamicClientRegistrationRequest{
 			ClientName:   "Invalid Client",
 			RedirectURIs: []string{}, // Empty redirect URIs should cause error
+			Scope:        "openid profile email",
 		}
 
 		response, err := service.DynamicClientRegistration(ctx, request)
@@ -533,6 +534,7 @@ func TestValidateDynamicClientRegistrationRequest(t *testing.T) {
 		request := &types.DynamicClientRegistrationRequest{
 			ClientName:   "No Redirect URIs",
 			RedirectURIs: []string{},
+			Scope:        "openid profile email",
 		}
 
 		err := service.validateDynamicClientRegistrationRequest(request)
@@ -548,6 +550,7 @@ func TestValidateDynamicClientRegistrationRequest(t *testing.T) {
 		request := &types.DynamicClientRegistrationRequest{
 			ClientName:   "Invalid Redirect URI",
 			RedirectURIs: []string{"://invalid-uri"},
+			Scope:        "openid profile email",
 		}
 
 		err := service.validateDynamicClientRegistrationRequest(request)


### PR DESCRIPTION
- Updated test cases for dynamic client registration to include a scope field with values "openid profile email".
- Ensured that tests reflect the expected behavior when scope is provided, enhancing validation coverage for client registration requests.