### PR TITLE
Enhance refresh token functionality and response handling

### DIFF
--- a/openapi/signin/api.go
+++ b/openapi/signin/api.go
@@ -214,7 +214,18 @@ func authback(c *gin.Context) {
 		return
 	}
 
-	response.RespondWithSuccess(c, response.StatusOK, loginResponse)
+	// Authorize Cookie
+	accessToken := fmt.Sprintf("%s %s", loginResponse.TokenType, loginResponse.AccessToken)
+	refreshToken := fmt.Sprintf("%s %s", loginResponse.TokenType, loginResponse.RefreshToken)
+
+	// Send Cookie
+	expires := time.Now().Add(time.Duration(loginResponse.ExpiresIn) * time.Second)
+	refreshExpires := time.Now().Add(time.Duration(loginResponse.RefreshTokenExpiresIn) * time.Second)
+	response.SendAccessTokenCookieWithExpiry(c, accessToken, expires)
+	response.SendRefreshTokenCookieWithExpiry(c, refreshToken, refreshExpires)
+
+	// Send IDToken to the client
+	response.RespondWithSuccess(c, response.StatusOK, map[string]interface{}{"id_token": loginResponse.IDToken})
 }
 
 // getOAuthAuthorizationURL generates OAuth authorization URL for a provider

--- a/openapi/signin/login.go
+++ b/openapi/signin/login.go
@@ -119,17 +119,18 @@ func LoginByUserID(userid string, ip string) (*LoginResponse, error) {
 	}
 
 	// Refresh Token
-	refreshToken, err := oauth.OAuth.MakeRefreshToken(yaoClientConfig.ClientID, strings.Join(scopes, " "), subject)
+	refreshToken, err := oauth.OAuth.MakeRefreshToken(yaoClientConfig.ClientID, strings.Join(scopes, " "), subject, yaoClientConfig.RefreshTokenExpiresIn)
 	if err != nil {
 		return nil, err
 	}
 
 	return &LoginResponse{
-		AccessToken:  accessToken,
-		IDToken:      oidcToken,
-		RefreshToken: refreshToken,
-		ExpiresIn:    yaoClientConfig.ExpiresIn,
-		TokenType:    "Bearer",
-		Scope:        strings.Join(scopes, " "),
+		AccessToken:           accessToken,
+		IDToken:               oidcToken,
+		RefreshToken:          refreshToken,
+		ExpiresIn:             yaoClientConfig.ExpiresIn,
+		RefreshTokenExpiresIn: yaoClientConfig.RefreshTokenExpiresIn,
+		TokenType:             "Bearer",
+		Scope:                 strings.Join(scopes, " "),
 	}, nil
 }

--- a/openapi/signin/signin.go
+++ b/openapi/signin/signin.go
@@ -156,7 +156,8 @@ func registerClient(clientID string) (*YaoClientConfig, error) {
 	var clientConfig *YaoClientConfig = &YaoClientConfig{}
 	clientConfig.ClientID = response.ClientID
 	clientConfig.ClientSecret = response.ClientSecret
-	clientConfig.ExpiresIn = 3600 * 24 // 24 hours
+	clientConfig.ExpiresIn = 3600 * 24                  // 24 hours
+	clientConfig.RefreshTokenExpiresIn = 3600 * 24 * 30 // 30 days
 	clientConfig.Scopes = []string{"openid", "profile", "email"}
 	return clientConfig, nil
 }

--- a/openapi/signin/types.go
+++ b/openapi/signin/types.go
@@ -66,10 +66,11 @@ type RegisterConfig struct {
 
 // YaoClientConfig represents the Yao OpenAPI Client config
 type YaoClientConfig struct {
-	ClientID     string   `json:"client_id,omitempty"`
-	ClientSecret string   `json:"client_secret,omitempty"`
-	Scopes       []string `json:"scopes,omitempty"`     // Default scopes if not set in the provider config
-	ExpiresIn    int      `json:"expires_in,omitempty"` // Default expires in for the access token (optional) in seconds
+	ClientID              string   `json:"client_id,omitempty"`
+	ClientSecret          string   `json:"client_secret,omitempty"`
+	Scopes                []string `json:"scopes,omitempty"`                   // Default scopes if not set in the provider config
+	ExpiresIn             int      `json:"expires_in,omitempty"`               // Default expires in for the access token (optional) in seconds
+	RefreshTokenExpiresIn int      `json:"refresh_token_expires_in,omitempty"` // Default expires in for the refresh token (optional) in seconds
 }
 
 // Provider represents a third party login provider
@@ -161,12 +162,13 @@ type OIDCAddress = oauthtypes.OIDCAddress
 
 // LoginResponse represents the response for login
 type LoginResponse struct {
-	AccessToken  string `json:"access_token"`
-	IDToken      string `json:"id_token,omitempty"`
-	RefreshToken string `json:"refresh_token,omitempty"`
-	ExpiresIn    int    `json:"expires_in,omitempty"`
-	TokenType    string `json:"token_type,omitempty"`
-	Scope        string `json:"scope,omitempty"`
+	AccessToken           string `json:"access_token"`
+	IDToken               string `json:"id_token,omitempty"`
+	RefreshToken          string `json:"refresh_token,omitempty"`
+	ExpiresIn             int    `json:"expires_in,omitempty"`
+	RefreshTokenExpiresIn int    `json:"refresh_token_expires_in,omitempty"`
+	TokenType             string `json:"token_type,omitempty"`
+	Scope                 string `json:"scope,omitempty"`
 }
 
 // Built-in preset mapping types


### PR DESCRIPTION
- Updated MakeRefreshToken and generateRefreshToken methods to accept an optional expiresIn parameter for customizable token expiration.
- Modified storeRefreshTokenWithScope to handle dynamic expiration times based on the provided parameter.
- Enhanced the authback function to send cookies with access and refresh tokens, including their respective expiration times.
- Updated LoginResponse structure to include RefreshTokenExpiresIn for better client-side management of token lifetimes.
- Adjusted client configuration to set default refresh token expiration duration.