### PR TITLE
Update collection validation to ignore empty collection name error

### DIFF
--- a/openapi/kb/collection.go
+++ b/openapi/kb/collection.go
@@ -221,8 +221,8 @@ func validateCreateCollectionRequest(req *CreateCollectionRequest) error {
 		return fmt.Errorf("config is required")
 	}
 
-	// Validate CreateCollectionOptions
-	if err := req.Config.Validate(); err != nil {
+	// Validate CreateCollectionOptions (ignore collection name cannot be empty error)
+	if err := req.Config.Validate(); err != nil && err.Error() != "collection name cannot be empty" {
 		return fmt.Errorf("invalid config: %w", err)
 	}
 


### PR DESCRIPTION
- Modified the validation logic in the CreateCollectionRequest to allow the "collection name cannot be empty" error to be ignored during CreateCollectionOptions validation, improving flexibility in request handling.