### PR TITLE
Add UpdateCollectionMetadata functionality

### DIFF
--- a/openapi/kb/kb.go
+++ b/openapi/kb/kb.go
@@ -24,6 +24,7 @@ func Attach(group *gin.RouterGroup, oauth types.OAuth) {
 	group.DELETE("/collections/:collectionID", RemoveCollection)
 	group.GET("/collections/:collectionID/exists", CollectionExists)
 	group.GET("/collections", GetCollections)
+	group.PUT("/collections/:collectionID/metadata", UpdateCollectionMetadata)
 
 	// Document Management
 	group.POST("/collections/:collectionID/documents/file", AddFile)


### PR DESCRIPTION
- Implemented UpdateCollectionMetadata function to handle metadata updates for existing collections.
- Added request structure and validation for updating collection metadata.
- Integrated new endpoint in the router for updating collection metadata via PUT request.