### PR TITLE
Update Schema methods to include locale parameter for providers

### DIFF
--- a/kb/providers/chunking.go
+++ b/kb/providers/chunking.go
@@ -95,7 +95,7 @@ func (s *Structured) Options(option *kbtypes.ProviderOption) (*types.ChunkingOpt
 }
 
 // Schema returns the schema for the structured chunking provider
-func (s *Structured) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (s *Structured) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }
 
@@ -240,6 +240,6 @@ func (s *Semantic) Options(option *kbtypes.ProviderOption) (*types.ChunkingOptio
 }
 
 // Schema returns the schema for the semantic chunking provider
-func (s *Semantic) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (s *Semantic) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }

--- a/kb/providers/converters/mcp.go
+++ b/kb/providers/converters/mcp.go
@@ -127,6 +127,6 @@ func (mcp *MCP) AutoDetect(filename, contentTypes string) (bool, int, error) {
 }
 
 // Schema returns the schema for the MCP converter
-func (mcp *MCP) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (mcp *MCP) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }

--- a/kb/providers/converters/mcp_test.go
+++ b/kb/providers/converters/mcp_test.go
@@ -220,7 +220,7 @@ func TestMCP_AutoDetect(t *testing.T) {
 
 func TestMCP_Schema(t *testing.T) {
 	mcp := &MCP{}
-	schema, err := mcp.Schema(nil)
+	schema, err := mcp.Schema(nil, "en")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}

--- a/kb/providers/converters/ocr.go
+++ b/kb/providers/converters/ocr.go
@@ -168,6 +168,6 @@ func (ocr *OCR) AutoDetect(filename, contentTypes string) (bool, int, error) {
 }
 
 // Schema returns the schema for the OCR converter
-func (ocr *OCR) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (ocr *OCR) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }

--- a/kb/providers/converters/ocr_test.go
+++ b/kb/providers/converters/ocr_test.go
@@ -397,7 +397,7 @@ func TestOCR_AutoDetect(t *testing.T) {
 
 func TestOCR_Schema(t *testing.T) {
 	ocr := &OCR{}
-	schema, err := ocr.Schema(nil)
+	schema, err := ocr.Schema(nil, "en")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}

--- a/kb/providers/converters/office.go
+++ b/kb/providers/converters/office.go
@@ -108,6 +108,6 @@ func (office *Office) AutoDetect(filename, contentTypes string) (bool, int, erro
 }
 
 // Schema returns the schema for the Office converter
-func (office *Office) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (office *Office) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }

--- a/kb/providers/converters/office_test.go
+++ b/kb/providers/converters/office_test.go
@@ -303,7 +303,7 @@ func TestOffice_AutoDetect(t *testing.T) {
 
 func TestOffice_Schema(t *testing.T) {
 	office := &Office{}
-	schema, err := office.Schema(nil)
+	schema, err := office.Schema(nil, "en")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}

--- a/kb/providers/converters/utf8.go
+++ b/kb/providers/converters/utf8.go
@@ -43,6 +43,6 @@ func (utf8 *UTF8) AutoDetect(filename, contentTypes string) (bool, int, error) {
 }
 
 // Schema returns the schema for the UTF8 converter
-func (utf8 *UTF8) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (utf8 *UTF8) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }

--- a/kb/providers/converters/utf8_test.go
+++ b/kb/providers/converters/utf8_test.go
@@ -121,7 +121,7 @@ func TestUTF8_AutoDetect(t *testing.T) {
 
 func TestUTF8_Schema(t *testing.T) {
 	utf8 := &UTF8{}
-	schema, err := utf8.Schema(nil)
+	schema, err := utf8.Schema(nil, "en")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}

--- a/kb/providers/converters/video.go
+++ b/kb/providers/converters/video.go
@@ -189,6 +189,6 @@ func (video *Video) AutoDetect(filename, contentTypes string) (bool, int, error)
 }
 
 // Schema returns the schema for the Video converter
-func (video *Video) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (video *Video) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }

--- a/kb/providers/converters/video_test.go
+++ b/kb/providers/converters/video_test.go
@@ -244,7 +244,7 @@ func TestVideo_AutoDetect(t *testing.T) {
 
 func TestVideo_Schema(t *testing.T) {
 	video := &Video{}
-	schema, err := video.Schema(nil)
+	schema, err := video.Schema(nil, "en")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}

--- a/kb/providers/converters/vision.go
+++ b/kb/providers/converters/vision.go
@@ -93,6 +93,6 @@ func (vision *Vision) AutoDetect(filename, contentTypes string) (bool, int, erro
 }
 
 // Schema returns the schema for the Vision converter
-func (vision *Vision) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (vision *Vision) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }

--- a/kb/providers/converters/vision_test.go
+++ b/kb/providers/converters/vision_test.go
@@ -182,7 +182,7 @@ func TestVision_AutoDetect(t *testing.T) {
 
 func TestVision_Schema(t *testing.T) {
 	vision := &Vision{}
-	schema, err := vision.Schema(nil)
+	schema, err := vision.Schema(nil, "en")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}

--- a/kb/providers/converters/whisper.go
+++ b/kb/providers/converters/whisper.go
@@ -143,6 +143,6 @@ func (whisper *Whisper) AutoDetect(filename, contentTypes string) (bool, int, er
 }
 
 // Schema returns the schema for the Whisper converter
-func (whisper *Whisper) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (whisper *Whisper) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }

--- a/kb/providers/converters/whisper_test.go
+++ b/kb/providers/converters/whisper_test.go
@@ -213,7 +213,7 @@ func TestWhisper_AutoDetect(t *testing.T) {
 
 func TestWhisper_Schema(t *testing.T) {
 	whisper := &Whisper{}
-	schema, err := whisper.Schema(nil)
+	schema, err := whisper.Schema(nil, "en")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}

--- a/kb/providers/embedding.go
+++ b/kb/providers/embedding.go
@@ -70,7 +70,7 @@ func (o *OpenAI) Make(option *kbtypes.ProviderOption) (types.Embedding, error) {
 }
 
 // Schema returns the schema for the OpenAI embedding provider
-func (o *OpenAI) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (o *OpenAI) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }
 
@@ -141,6 +141,6 @@ func (f *Fastembed) Make(option *kbtypes.ProviderOption) (types.Embedding, error
 }
 
 // Schema returns the schema for the Fastembed embedding provider
-func (f *Fastembed) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (f *Fastembed) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }

--- a/kb/providers/embedding_test.go
+++ b/kb/providers/embedding_test.go
@@ -122,7 +122,7 @@ func TestOpenAI_Make(t *testing.T) {
 
 func TestOpenAI_Schema(t *testing.T) {
 	openai := &OpenAI{}
-	schema, err := openai.Schema(nil)
+	schema, err := openai.Schema(nil, "en")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -283,7 +283,7 @@ func TestFastembed_Make(t *testing.T) {
 
 func TestFastembed_Schema(t *testing.T) {
 	fastembed := &Fastembed{}
-	schema, err := fastembed.Schema(nil)
+	schema, err := fastembed.Schema(nil, "en")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}

--- a/kb/providers/extractor.go
+++ b/kb/providers/extractor.go
@@ -128,6 +128,6 @@ func (e *ExtractorOpenAI) Make(option *kbtypes.ProviderOption) (types.Extraction
 }
 
 // Schema returns the schema for the OpenAI extractor provider
-func (e *ExtractorOpenAI) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (e *ExtractorOpenAI) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }

--- a/kb/providers/extractor_test.go
+++ b/kb/providers/extractor_test.go
@@ -279,7 +279,7 @@ func TestExtractorOpenAI_Make(t *testing.T) {
 
 func TestExtractorOpenAI_Schema(t *testing.T) {
 	extractor := &ExtractorOpenAI{}
-	schema, err := extractor.Schema(nil)
+	schema, err := extractor.Schema(nil, "en")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}

--- a/kb/providers/factory/factory.go
+++ b/kb/providers/factory/factory.go
@@ -129,7 +129,7 @@ func MakeFetcher(id string, option *kbtypes.ProviderOption) (types.Fetcher, erro
 // === Schema API ===
 
 // GetSchema returns the schema for a provider
-func GetSchema(typ ProviderType, provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func GetSchema(typ ProviderType, provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	var schema Schema = nil
 	var exists bool = false
 	switch typ {
@@ -147,5 +147,5 @@ func GetSchema(typ ProviderType, provider *kbtypes.Provider) (*kbtypes.ProviderS
 	if !exists {
 		return nil, fmt.Errorf("%s provider %s not found", typ, provider.ID)
 	}
-	return schema.Schema(provider)
+	return schema.Schema(provider, locale)
 }

--- a/kb/providers/factory/interfaces.go
+++ b/kb/providers/factory/interfaces.go
@@ -39,5 +39,5 @@ type Fetcher interface {
 
 // Schema interface for providers
 type Schema interface {
-	Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error)
+	Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error)
 }

--- a/kb/providers/fetcher.go
+++ b/kb/providers/fetcher.go
@@ -66,7 +66,7 @@ func (f *FetcherHTTP) Make(option *kbtypes.ProviderOption) (types.Fetcher, error
 }
 
 // Schema returns the schema for the HTTP fetcher provider
-func (f *FetcherHTTP) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (f *FetcherHTTP) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }
 
@@ -155,6 +155,6 @@ func (f *FetcherMCP) Make(option *kbtypes.ProviderOption) (types.Fetcher, error)
 }
 
 // Schema returns the schema for the MCP fetcher provider
-func (f *FetcherMCP) Schema(provider *kbtypes.Provider) (*kbtypes.ProviderSchema, error) {
+func (f *FetcherMCP) Schema(provider *kbtypes.Provider, locale string) (*kbtypes.ProviderSchema, error) {
 	return nil, nil
 }

--- a/kb/providers/fetcher_test.go
+++ b/kb/providers/fetcher_test.go
@@ -183,7 +183,7 @@ func TestFetcherHTTP_Make(t *testing.T) {
 
 func TestFetcherHTTP_Schema(t *testing.T) {
 	fetcher := &FetcherHTTP{}
-	schema, err := fetcher.Schema(nil)
+	schema, err := fetcher.Schema(nil, "en")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
@@ -441,7 +441,7 @@ func TestFetcherMCP_Make(t *testing.T) {
 
 func TestFetcherMCP_Schema(t *testing.T) {
 	fetcher := &FetcherMCP{}
-	schema, err := fetcher.Schema(nil)
+	schema, err := fetcher.Schema(nil, "en")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}


### PR DESCRIPTION
- Modified Schema methods across various providers (chunking, embedding, extractor, fetcher, converters) to accept an additional locale parameter, enhancing localization support.
- Updated corresponding test cases to reflect the changes in method signatures and ensure proper functionality with the new locale argument.