### PR TITLE
Update test for Config struct to clarify feature computation timing

### DIFF
--- a/kb/types/config_test.go
+++ b/kb/types/config_test.go
@@ -164,7 +164,13 @@ func TestConfig_UnmarshalJSON(t *testing.T) {
 		t.Errorf("Expected vector driver 'qdrant', got '%s'", config.Vector.Driver)
 	}
 
-	// Verify Features are computed automatically
+	// Verify that Features are not computed during UnmarshalJSON (they should be computed later)
+	// Features will be computed after providers are loaded in the actual Load function
+
+	// But we can manually compute features to test the logic
+	config.Features = config.ComputeFeatures()
+
+	// These should be true based on the config content (graph, pdf, ffmpeg are present)
 	if !config.Features.GraphDatabase {
 		t.Error("Expected GraphDatabase feature to be true")
 	}


### PR DESCRIPTION
- Modified the test case for UnmarshalJSON in config_test.go to specify that features are not computed during the unmarshalling process but rather after providers are loaded.
- Added comments to explain the manual computation of features for testing purposes, ensuring clarity in the test logic.