### PR TITLE
Add tests for Structured and Semantic schema retrieval

### DIFF
--- a/kb/providers/chunking_test.go
+++ b/kb/providers/chunking_test.go
@@ -400,3 +400,25 @@ func TestSemantic_Options(t *testing.T) {
 		}
 	})
 }
+
+func TestStructured_Schema(t *testing.T) {
+	s := &Structured{}
+	schema, err := s.Schema(nil, "en")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
+	}
+}
+
+func TestSemantic_Schema(t *testing.T) {
+	s := &Semantic{}
+	schema, err := s.Schema(nil, "en")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
+	}
+}

--- a/kb/providers/converters/mcp_test.go
+++ b/kb/providers/converters/mcp_test.go
@@ -224,7 +224,7 @@ func TestMCP_Schema(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if schema != nil {
-		t.Error("Expected nil schema")
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
 	}
 }

--- a/kb/providers/converters/ocr_test.go
+++ b/kb/providers/converters/ocr_test.go
@@ -401,7 +401,7 @@ func TestOCR_Schema(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if schema != nil {
-		t.Error("Expected nil schema")
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
 	}
 }

--- a/kb/providers/converters/office_test.go
+++ b/kb/providers/converters/office_test.go
@@ -307,7 +307,7 @@ func TestOffice_Schema(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if schema != nil {
-		t.Error("Expected nil schema")
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
 	}
 }

--- a/kb/providers/converters/utf8_test.go
+++ b/kb/providers/converters/utf8_test.go
@@ -125,7 +125,7 @@ func TestUTF8_Schema(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if schema != nil {
-		t.Error("Expected nil schema")
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
 	}
 }

--- a/kb/providers/converters/video_test.go
+++ b/kb/providers/converters/video_test.go
@@ -248,7 +248,7 @@ func TestVideo_Schema(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if schema != nil {
-		t.Error("Expected nil schema")
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
 	}
 }

--- a/kb/providers/converters/vision_test.go
+++ b/kb/providers/converters/vision_test.go
@@ -186,7 +186,7 @@ func TestVision_Schema(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if schema != nil {
-		t.Error("Expected nil schema")
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
 	}
 }

--- a/kb/providers/converters/whisper_test.go
+++ b/kb/providers/converters/whisper_test.go
@@ -217,7 +217,7 @@ func TestWhisper_Schema(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if schema != nil {
-		t.Error("Expected nil schema")
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
 	}
 }

--- a/kb/providers/embedding_test.go
+++ b/kb/providers/embedding_test.go
@@ -126,8 +126,8 @@ func TestOpenAI_Schema(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if schema != nil {
-		t.Error("Expected nil schema")
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
 	}
 }
 
@@ -287,7 +287,7 @@ func TestFastembed_Schema(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if schema != nil {
-		t.Error("Expected nil schema")
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
 	}
 }

--- a/kb/providers/extractor_test.go
+++ b/kb/providers/extractor_test.go
@@ -283,7 +283,7 @@ func TestExtractorOpenAI_Schema(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if schema != nil {
-		t.Error("Expected nil schema")
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
 	}
 }

--- a/kb/providers/fetcher_test.go
+++ b/kb/providers/fetcher_test.go
@@ -187,8 +187,8 @@ func TestFetcherHTTP_Schema(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if schema != nil {
-		t.Error("Expected nil schema")
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
 	}
 }
 
@@ -445,7 +445,7 @@ func TestFetcherMCP_Schema(t *testing.T) {
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	if schema != nil {
-		t.Error("Expected nil schema")
+	if schema == nil {
+		t.Error("Expected non-nil schema from factory.GetSchemaFromBindata")
 	}
 }


### PR DESCRIPTION
- Introduced new test cases for Structured and Semantic providers to validate schema retrieval functionality.
- Updated existing tests across various providers to ensure they check for non-nil schemas, enhancing error handling and test coverage.
- Ensured consistency in error messages for schema validation across different provider tests.