### PR TITLE
Refactor provider option resolution to require provider type

### DIFF
--- a/kb/types/provider.go
+++ b/kb/types/provider.go
@@ -16,7 +16,6 @@ func (p *Provider) GetOption(id string) (*ProviderOption, bool) {
 		return nil, false
 	}
 
-	// Find the option by id
 	for _, option := range p.Options {
 		if option.Value == id {
 			return option, true


### PR DESCRIPTION
- Updated the resolveProviderOption function to include providerType as a required parameter, enhancing error handling for missing provider types.
- Simplified the provider retrieval logic to directly fetch providers based on the specified type, improving clarity and maintainability.
- Removed redundant comments and streamlined the code for better readability.