### PR TITLE
Refactor error handling in category retrieval test and enhance time f…

### DIFF
--- a/job/data_test.go
+++ b/job/data_test.go
@@ -168,7 +168,7 @@ func TestCategoryCRUD(t *testing.T) {
 		t.Fatalf("Failed to get categories: %v", err)
 	}
 	if len(categories) == 0 {
-		t.Error("Expected to find the test category")
+		t.Fatal("Expected to find the test category")
 	}
 	if categories[0].Name != testCategory.Name {
 		t.Errorf("Expected category name '%s', got '%s'", testCategory.Name, categories[0].Name)


### PR DESCRIPTION
…ield processing

- Updated the test for category retrieval to use t.Fatal instead of t.Error for critical failures, ensuring immediate test termination on error.
- Refactored the mapToStruct function to improve handling of boolean and time fields, converting database time formats to RFC3339 and ensuring proper type conversions for specific keys.