### PR TITLE
Add MFA support to login response and related structures

### DIFF
--- a/openapi/user/login.go
+++ b/openapi/user/login.go
@@ -193,6 +193,9 @@ func LoginByUserID(userid string, ip string) (*LoginResponse, error) {
 		return nil, err
 	}
 
+	// Get MFA enabled status from user data
+	mfaEnabled := toBool(user["mfa_enabled"])
+
 	return &LoginResponse{
 		AccessToken:           accessToken,
 		IDToken:               oidcToken,
@@ -200,6 +203,7 @@ func LoginByUserID(userid string, ip string) (*LoginResponse, error) {
 		ExpiresIn:             yaoClientConfig.ExpiresIn,
 		RefreshTokenExpiresIn: yaoClientConfig.RefreshTokenExpiresIn,
 		TokenType:             "Bearer",
+		MFAEnabled:            mfaEnabled,
 		Scope:                 strings.Join(scopes, " "),
 	}, nil
 }

--- a/openapi/user/oauth.go
+++ b/openapi/user/oauth.go
@@ -195,6 +195,7 @@ func authback(c *gin.Context) {
 		RefreshToken:          loginResponse.RefreshToken,
 		ExpiresIn:             loginResponse.ExpiresIn,
 		RefreshTokenExpiresIn: loginResponse.RefreshTokenExpiresIn,
+		MFAEnabled:            loginResponse.MFAEnabled,
 	})
 }
 

--- a/openapi/user/types.go
+++ b/openapi/user/types.go
@@ -169,6 +169,7 @@ type LoginResponse struct {
 	ExpiresIn             int    `json:"expires_in,omitempty"`
 	RefreshTokenExpiresIn int    `json:"refresh_token_expires_in,omitempty"`
 	TokenType             string `json:"token_type,omitempty"`
+	MFAEnabled            bool   `json:"mfa_enabled,omitempty"`
 	Scope                 string `json:"scope,omitempty"`
 }
 
@@ -179,6 +180,7 @@ type LoginSuccessResponse struct {
 	SessionID             string `json:"session_id,omitempty"`
 	RefreshToken          string `json:"refresh_token,omitempty"`
 	ExpiresIn             int    `json:"expires_in,omitempty"`
+	MFAEnabled            bool   `json:"mfa_enabled"`
 	RefreshTokenExpiresIn int    `json:"refresh_token_expires_in,omitempty"`
 }
 
@@ -198,3 +200,27 @@ const (
 	UserInfoSourceIDToken     = "id_token"     // Extract user info from ID token (JWT)
 	UserInfoSourceAccessToken = "access_token" // Extract user info from access token response
 )
+
+// toBool converts various types to boolean
+// Supports: bool, int, int64, float64, string
+// Returns false for nil or unsupported types
+func toBool(v interface{}) bool {
+	if v == nil {
+		return false
+	}
+
+	switch val := v.(type) {
+	case bool:
+		return val
+	case int:
+		return val != 0
+	case int64:
+		return val != 0
+	case float64:
+		return val != 0
+	case string:
+		return val == "true" || val == "1"
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
- Updated the LoginResponse structure to include MFAEnabled status, reflecting the user's MFA configuration.
- Modified the authback function in oauth.go to return the MFAEnabled status in the response.
- Introduced a utility function to convert various types to boolean for determining MFA status from user data.