### PR TITLE
feat(chat): add last_workspace tracking and update session management

### DIFF
--- a/agent/assistant/chat.go
+++ b/agent/assistant/chat.go
@@ -238,6 +238,12 @@ func (ast *Assistant) FlushBuffer(ctx *agentcontext.Context, finalStatus string,
 		if mode := ctx.Buffer.Mode(); mode != "" {
 			updates["last_mode"] = mode
 		}
+		// Also update last_workspace if available in metadata
+		if ctx.Metadata != nil {
+			if ws, ok := ctx.Metadata["workspace_id"].(string); ok && ws != "" {
+				updates["last_workspace"] = ws
+			}
+		}
 		if updateErr := chatStore.UpdateChat(ctx.ChatID, updates); updateErr != nil {
 			ctx.Logger.Debug("Failed to update chat: %v", updateErr)
 		}
@@ -357,6 +363,13 @@ func (ast *Assistant) EnsureChat(ctx *agentcontext.Context) error {
 	// Set last_connector from options (user selected connector)
 	if ctx.Stack != nil && ctx.Stack.Options != nil && ctx.Stack.Options.Connector != "" {
 		chat.LastConnector = ctx.Stack.Options.Connector
+	}
+
+	// Set last_workspace from metadata
+	if ctx.Metadata != nil {
+		if ws, ok := ctx.Metadata["workspace_id"].(string); ok && ws != "" {
+			chat.LastWorkspace = ws
+		}
 	}
 
 	// Set permission fields from authorized info

--- a/agent/sandbox/v2/claude/command.go
+++ b/agent/sandbox/v2/claude/command.go
@@ -73,7 +73,7 @@ func (r *Runner) buildCommand(ctx context.Context, req *types.StreamRequest, p p
 
 	var isContinuation bool
 	if chatID != "" {
-		storeKey := "claude-session:" + assistantID + ":" + chatID
+		storeKey := "claude-session:" + assistantID + ":" + chatID + ":" + req.Config.WorkspaceID
 		isContinuation = chatSessionExists(storeKey)
 	} else {
 		isContinuation = hasExistingSession(ctx, computer, p, assistantID)

--- a/agent/sandbox/v2/claude/runner.go
+++ b/agent/sandbox/v2/claude/runner.go
@@ -162,7 +162,7 @@ func (r *Runner) Stream(ctx context.Context, req *types.StreamRequest, handler m
 	// Claude CLI creates session files on disk at startup, so subsequent
 	// requests must use --resume (not --session-id) even if this stream fails.
 	if chatID != "" {
-		storeKey := "claude-session:" + assistantID + ":" + chatID
+		storeKey := "claude-session:" + assistantID + ":" + chatID + ":" + req.Config.WorkspaceID
 		sessionUUID := chatIDToSessionUUID(assistantID, chatID)
 		markChatSession(storeKey, sessionUUID, 90*24*time.Hour)
 	}

--- a/agent/sandbox/v2/opencode/command.go
+++ b/agent/sandbox/v2/opencode/command.go
@@ -59,7 +59,7 @@ func (r *Runner) buildCommand(req *types.StreamRequest, p platform, attachmentPa
 
 	var isContinuation bool
 	if chatID != "" {
-		storeKey := "opencode-session:" + assistantID + ":" + chatID
+		storeKey := "opencode-session:" + assistantID + ":" + chatID + ":" + req.Config.WorkspaceID
 		isContinuation = chatSessionExists(storeKey)
 	}
 

--- a/agent/sandbox/v2/opencode/runner.go
+++ b/agent/sandbox/v2/opencode/runner.go
@@ -153,7 +153,7 @@ func (r *Runner) Stream(ctx context.Context, req *types.StreamRequest, handler m
 	// Write system prompt if this is the first turn.
 	assistantID := req.AssistantID
 	chatID := req.ChatID
-	storeKey := "opencode-session:" + assistantID + ":" + chatID
+	storeKey := "opencode-session:" + assistantID + ":" + chatID + ":" + req.Config.WorkspaceID
 	isContinuation := chatID != "" && chatSessionExists(storeKey)
 
 	if !isContinuation && req.SystemPrompt != "" {

--- a/agent/store/types/types.go
+++ b/agent/store/types/types.go
@@ -33,6 +33,7 @@ type Chat struct {
 	AssistantID   string                 `json:"assistant_id"`
 	LastConnector string                 `json:"last_connector,omitempty"` // Last used connector ID (updated on each message)
 	LastMode      string                 `json:"last_mode,omitempty"`      // Last used chat mode (updated on each message)
+	LastWorkspace string                 `json:"last_workspace,omitempty"` // Last used workspace ID (updated on each message)
 	Status        string                 `json:"status"`                   // "active" or "archived"
 	Public        bool                   `json:"public"`                   // Whether shared across all teams
 	Share         string                 `json:"share"`                    // "private" or "team"

--- a/agent/store/xun/chat.go
+++ b/agent/store/xun/chat.go
@@ -76,6 +76,9 @@ func (store *Xun) CreateChat(chat *types.Chat) error {
 	if chat.LastMode != "" {
 		data["last_mode"] = chat.LastMode
 	}
+	if chat.LastWorkspace != "" {
+		data["last_workspace"] = chat.LastWorkspace
+	}
 	if chat.LastMessageAt != nil {
 		data["last_message_at"] = *chat.LastMessageAt
 	}
@@ -346,6 +349,7 @@ func (store *Xun) rowToChat(data map[string]interface{}) (*types.Chat, error) {
 		AssistantID:   getString(data, "assistant_id"),
 		LastConnector: getString(data, "last_connector"),
 		LastMode:      getString(data, "last_mode"),
+		LastWorkspace: getString(data, "last_workspace"),
 		Status:        getString(data, "status"),
 		Public:        getBool(data, "public"),
 		Share:         getString(data, "share"),

--- a/yao/models/agent/chat.mod.yao
+++ b/yao/models/agent/chat.mod.yao
@@ -58,6 +58,15 @@
       "nullable": true
     },
     {
+      "name": "last_workspace",
+      "type": "string",
+      "label": "Last Workspace",
+      "comment": "Last used workspace ID (updated on each message)",
+      "length": 200,
+      "nullable": true,
+      "index": true
+    },
+    {
       "name": "status",
       "type": "enum",
       "label": "Status",


### PR DESCRIPTION
Enhanced chat functionality by introducing last_workspace tracking in the Assistant and Chat structures. Updated session management in Claude and Opencode runners to include workspace ID in session keys, improving session handling and organization. This change ensures better context management across different workspaces during chat interactions.