### PR TITLE
refactor(clip): simplify clip ID generation and update documentation

### DIFF
--- a/tools/clip/clip.go
+++ b/tools/clip/clip.go
@@ -49,7 +49,7 @@ func cleanupLoop() {
 }
 
 func newClipID() string {
-	return "clip://" + uuid.New().String()
+	return uuid.New().String()
 }
 
 func writeClip(userID, teamID, label, description string, data map[string]string) *Clip {

--- a/tools/clip/read.go
+++ b/tools/clip/read.go
@@ -14,7 +14,7 @@ var ReadSchemaJSON []byte
 // ReadHandler is the tools.clip_read process handler.
 // Reads a stored clip by ID and returns the full content.
 //
-// Args[0]: id (string) — the clip ID (e.g. clip://uuid)
+// Args[0]: id (string) — the clip ID (UUID string)
 func ReadHandler(proc *process.Process) interface{} {
 	id := proc.ArgsString(0)
 	if id == "" {

--- a/tools/clip/read_schema.json
+++ b/tools/clip/read_schema.json
@@ -1,11 +1,11 @@
 {
   "name": "clip_read",
-  "description": "Read a stored clip by ID. Use when you see <Mention type=\"clip\" value=\"clip://...\"> in user messages and need the full content.",
+  "description": "Read a stored clip by ID. Use when you see <Mention type=\"clip\"> in user messages and need the full content.",
   "process": "tools.clip_read",
   "inputSchema": {
     "type": "object",
     "properties": {
-      "id": { "type": "string", "description": "The clip ID (e.g. clip://uuid)" }
+      "id": { "type": "string", "description": "The clip ID (UUID string from Mention value)" }
     },
     "required": ["id"]
   },

--- a/tools/prompts/system-tools.md
+++ b/tools/prompts/system-tools.md
@@ -117,6 +117,6 @@ User messages may contain `<Mention>` tags referencing experts, workspaces, file
 - `<Mention type="workspace" value="workspace_id">Name</Mention>` — References a workspace. Use `workspace_file_list` and `workspace_file_read` to access its files.
 - `<Mention type="file" value="workspace://wsId/path">Filename</Mention>` — References a specific file. Use `workspace_file_read` to read its content.
 - `<Mention type="directory" value="workspace://wsId/path">DirName</Mention>` — References a directory. Use `workspace_file_list` to browse its contents first, then `workspace_file_read` for specific files.
-- `<Mention type="clip" value="clip://uuid" description="...">Label</Mention>` — References a stored content clip. The `description` attribute tells you what the clip contains. Use `tai tool clip_read '{"id":"<the value>"}'` to retrieve the full data when needed.
+- `<Mention type="clip" value="<uuid>" description="...">Label</Mention>` — References a stored content clip. The `description` attribute tells you what the clip contains. Use `tai tool clip_read '{"id":"<the value>"}'` to retrieve the full data when needed.
 
 When you see these tags, understand the user's intent and use the appropriate tools.


### PR DESCRIPTION
Removed the "clip://" prefix from the newClipID function to return only the UUID string. Updated the read_schema.json and read.go files to clarify the clip ID format in the documentation. Adjusted system-tools.md to reflect the new mention format for clips, enhancing consistency across the codebase.