### PR TITLE
feat(tools): add mobile commands and update documentation

### DIFF
--- a/tools/mcps/mobile.json
+++ b/tools/mcps/mobile.json
@@ -1,0 +1,13 @@
+{
+  "name": "yao-mobile",
+  "transport": "process",
+  "description": "Mobile device management tools for controlling Android devices connected via Tai Link",
+  "tools": {
+    "mobile_list": "tools.mobile_list",
+    "mobile_exec": "tools.mobile_exec",
+    "mobile_screenshot": "tools.mobile_screenshot",
+    "mobile_info": "tools.mobile_info",
+    "mobile_push": "tools.mobile_push",
+    "mobile_pull": "tools.mobile_pull"
+  }
+}

--- a/tools/mobile/exec.go
+++ b/tools/mobile/exec.go
@@ -1,0 +1,54 @@
+package mobile
+
+import (
+	"context"
+	_ "embed"
+	"strings"
+
+	"github.com/yaoapp/gou/process"
+)
+
+//go:embed exec_schema.json
+var ExecSchemaJSON []byte
+
+// ExecHandler is the tools.mobile_exec process handler.
+// Executes a shell command on the target Android device.
+//
+// Args[0]: device_id (string)
+// Args[1]: command (string)
+func ExecHandler(proc *process.Process) interface{} {
+	deviceID, err := extractDeviceID(proc, 0)
+	if err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+
+	command := proc.ArgsString(1)
+	if command == "" {
+		return map[string]any{"error": "command is required"}
+	}
+
+	if _, err := getAndroidNode(deviceID); err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+
+	ctx := context.Background()
+	if proc.Context != nil {
+		ctx = proc.Context
+	}
+
+	stdout, stderr, exitCode, err := execOnDevice(ctx, deviceID, command)
+	if err != nil {
+		return map[string]any{
+			"error":     err.Error(),
+			"stdout":    strings.TrimSpace(stdout),
+			"stderr":    strings.TrimSpace(stderr),
+			"exit_code": exitCode,
+		}
+	}
+
+	return map[string]any{
+		"stdout":    strings.TrimSpace(stdout),
+		"stderr":    strings.TrimSpace(stderr),
+		"exit_code": exitCode,
+	}
+}

--- a/tools/mobile/exec_schema.json
+++ b/tools/mobile/exec_schema.json
@@ -1,0 +1,20 @@
+{
+  "name": "mobile_exec",
+  "description": "Execute a shell command on a connected Android device via Tai Link. Returns stdout, stderr, and exit code.",
+  "process": "tools.mobile_exec",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "device_id": {
+        "type": "string",
+        "description": "The Tai ID of the target Android device (from mobile_list)"
+      },
+      "command": {
+        "type": "string",
+        "description": "Shell command to execute on the device"
+      }
+    },
+    "required": ["device_id", "command"]
+  },
+  "x-process-args": ["$args.device_id", "$args.command"]
+}

--- a/tools/mobile/info.go
+++ b/tools/mobile/info.go
@@ -1,0 +1,51 @@
+package mobile
+
+import (
+	_ "embed"
+
+	"github.com/yaoapp/gou/process"
+)
+
+//go:embed info_schema.json
+var InfoSchemaJSON []byte
+
+// InfoHandler is the tools.mobile_info process handler.
+// Returns detailed information about a connected Android device.
+//
+// Args[0]: device_id (string)
+func InfoHandler(proc *process.Process) interface{} {
+	deviceID, err := extractDeviceID(proc, 0)
+	if err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+
+	meta, err := getAndroidNode(deviceID)
+	if err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+
+	caps := map[string]bool{}
+	if meta.Capabilities.HostExec {
+		caps["host_exec"] = true
+	}
+	if meta.Capabilities.Docker {
+		caps["docker"] = true
+	}
+	if meta.Capabilities.K8s {
+		caps["k8s"] = true
+	}
+	if meta.Capabilities.VNC {
+		caps["vnc"] = true
+	}
+
+	return map[string]any{
+		"device_id":    meta.TaiID,
+		"machine_id":   meta.MachineID,
+		"display_name": meta.DisplayName,
+		"hostname":     meta.System.Hostname,
+		"os":           meta.System.OS,
+		"arch":         meta.System.Arch,
+		"status":       meta.Status,
+		"capabilities": caps,
+	}
+}

--- a/tools/mobile/info_schema.json
+++ b/tools/mobile/info_schema.json
@@ -1,0 +1,16 @@
+{
+  "name": "mobile_info",
+  "description": "Get detailed information about a connected Android device, including OS, architecture, hostname, capabilities, and status.",
+  "process": "tools.mobile_info",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "device_id": {
+        "type": "string",
+        "description": "The Tai ID of the target Android device (from mobile_list)"
+      }
+    },
+    "required": ["device_id"]
+  },
+  "x-process-args": ["$args.device_id"]
+}

--- a/tools/mobile/list.go
+++ b/tools/mobile/list.go
@@ -1,0 +1,28 @@
+package mobile
+
+import (
+	_ "embed"
+
+	"github.com/yaoapp/gou/process"
+)
+
+//go:embed list_schema.json
+var ListSchemaJSON []byte
+
+// ListHandler is the tools.mobile_list process handler.
+// Returns all online Android devices.
+func ListHandler(proc *process.Process) interface{} {
+	nodes := listAndroidNodes()
+	devices := make([]map[string]any, 0, len(nodes))
+	for _, n := range nodes {
+		devices = append(devices, map[string]any{
+			"device_id":    n.TaiID,
+			"display_name": n.DisplayName,
+			"model":        n.System.Hostname,
+			"os":           n.System.OS,
+			"arch":         n.System.Arch,
+			"status":       n.Status,
+		})
+	}
+	return map[string]any{"devices": devices}
+}

--- a/tools/mobile/list_schema.json
+++ b/tools/mobile/list_schema.json
@@ -1,0 +1,10 @@
+{
+  "name": "mobile_list",
+  "description": "List all online Android mobile devices connected via Tai Link.",
+  "process": "tools.mobile_list",
+  "inputSchema": {
+    "type": "object",
+    "properties": {}
+  },
+  "x-process-args": []
+}

--- a/tools/mobile/mobile.go
+++ b/tools/mobile/mobile.go
@@ -1,0 +1,84 @@
+package mobile
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/yaoapp/gou/process"
+	tai "github.com/yaoapp/yao/tai"
+	hepb "github.com/yaoapp/yao/tai/hostexec/pb"
+	"github.com/yaoapp/yao/tai/registry"
+	"github.com/yaoapp/yao/tai/types"
+)
+
+func listAndroidNodes() []types.NodeMeta {
+	reg := registry.Global()
+	if reg == nil {
+		return nil
+	}
+	all := reg.List()
+	var result []types.NodeMeta
+	for _, n := range all {
+		if n.System.OS == "android" && n.Status == "online" {
+			result = append(result, n)
+		}
+	}
+	return result
+}
+
+func getAndroidNode(deviceID string) (*types.NodeMeta, error) {
+	meta, ok := tai.GetNodeMeta(deviceID)
+	if !ok {
+		return nil, fmt.Errorf("device %q not found", deviceID)
+	}
+	if meta.Status != "online" {
+		return nil, fmt.Errorf("device %q is offline", deviceID)
+	}
+	if meta.System.OS != "android" {
+		return nil, fmt.Errorf("device %q is not an Android device (os=%s)", deviceID, meta.System.OS)
+	}
+	return meta, nil
+}
+
+func getHostExec(deviceID string) (hepb.HostExecClient, func(), error) {
+	res, ok := tai.GetResources(deviceID)
+	if !ok {
+		return nil, nil, fmt.Errorf("device %q: no connection resources", deviceID)
+	}
+	if res.HostExec == nil {
+		return nil, nil, fmt.Errorf("device %q: host_exec not enabled", deviceID)
+	}
+	return res.HostExec, func() {}, nil
+}
+
+func execOnDevice(ctx context.Context, deviceID, command string) (string, string, int32, error) {
+	he, cleanup, err := getHostExec(deviceID)
+	if err != nil {
+		return "", "", -1, err
+	}
+	defer cleanup()
+
+	resp, err := he.Exec(ctx, &hepb.ExecRequest{
+		Command:   "sh",
+		Args:      []string{"-c", command},
+		TimeoutMs: 60000,
+	})
+	if err != nil {
+		return "", "", -1, fmt.Errorf("exec rpc: %w", err)
+	}
+
+	stdout := string(resp.Stdout)
+	stderr := string(resp.Stderr)
+	if resp.Error != "" {
+		return stdout, stderr, resp.ExitCode, fmt.Errorf("%s", resp.Error)
+	}
+	return stdout, stderr, resp.ExitCode, nil
+}
+
+func extractDeviceID(proc *process.Process, idx int) (string, error) {
+	id := proc.ArgsString(idx)
+	if id == "" {
+		return "", fmt.Errorf("device_id is required")
+	}
+	return id, nil
+}

--- a/tools/mobile/pull.go
+++ b/tools/mobile/pull.go
@@ -1,0 +1,78 @@
+package mobile
+
+import (
+	"context"
+	_ "embed"
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/yaoapp/gou/process"
+	tai "github.com/yaoapp/yao/tai"
+)
+
+//go:embed pull_schema.json
+var PullSchemaJSON []byte
+
+// PullHandler is the tools.mobile_pull process handler.
+// Pulls a file from the Android device to the Yao server (or returns base64).
+//
+// Args[0]: device_id (string)
+// Args[1]: remote_path (string) - source path on the device
+// Args[2]: local_path (string, optional) - destination path on the Yao server; if empty, returns content as base64
+func PullHandler(proc *process.Process) interface{} {
+	deviceID, err := extractDeviceID(proc, 0)
+	if err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+
+	remotePath := proc.ArgsString(1)
+	localPath := proc.ArgsString(2)
+
+	if remotePath == "" {
+		return map[string]any{"error": "remote_path is required"}
+	}
+
+	if _, err := getAndroidNode(deviceID); err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+
+	res, ok := tai.GetResources(deviceID)
+	if !ok {
+		return map[string]any{"error": fmt.Sprintf("device %q: no connection resources", deviceID)}
+	}
+	if res.Volume == nil {
+		return map[string]any{"error": fmt.Sprintf("device %q: volume not enabled", deviceID)}
+	}
+
+	ctx := context.Background()
+	if proc.Context != nil {
+		ctx = proc.Context
+	}
+
+	data, _, err := res.Volume.ReadFile(ctx, deviceID, remotePath)
+	if err != nil {
+		return map[string]any{"error": fmt.Sprintf("read from device: %v", err)}
+	}
+
+	if localPath != "" {
+		if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
+			return map[string]any{"error": fmt.Sprintf("create local dir: %v", err)}
+		}
+		if err := os.WriteFile(localPath, data, 0644); err != nil {
+			return map[string]any{"error": fmt.Sprintf("write local file: %v", err)}
+		}
+		return map[string]any{
+			"success":    true,
+			"local_path": localPath,
+			"bytes":      len(data),
+		}
+	}
+
+	return map[string]any{
+		"content_base64": base64.StdEncoding.EncodeToString(data),
+		"remote_path":    remotePath,
+		"bytes":          len(data),
+	}
+}

--- a/tools/mobile/pull_schema.json
+++ b/tools/mobile/pull_schema.json
@@ -1,0 +1,24 @@
+{
+  "name": "mobile_pull",
+  "description": "Pull a file from a connected Android device. If local_path is provided, saves to the Yao server; otherwise returns the file content as base64.",
+  "process": "tools.mobile_pull",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "device_id": {
+        "type": "string",
+        "description": "The Tai ID of the target Android device (from mobile_list)"
+      },
+      "remote_path": {
+        "type": "string",
+        "description": "Source file path on the Android device"
+      },
+      "local_path": {
+        "type": "string",
+        "description": "Destination path on the Yao server (optional; if omitted, content is returned as base64)"
+      }
+    },
+    "required": ["device_id", "remote_path"]
+  },
+  "x-process-args": ["$args.device_id", "$args.remote_path", "$args.local_path"]
+}

--- a/tools/mobile/push.go
+++ b/tools/mobile/push.go
@@ -1,0 +1,79 @@
+package mobile
+
+import (
+	"context"
+	_ "embed"
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/yaoapp/gou/process"
+	tai "github.com/yaoapp/yao/tai"
+)
+
+//go:embed push_schema.json
+var PushSchemaJSON []byte
+
+// PushHandler is the tools.mobile_push process handler.
+// Pushes a file from the Yao server (or base64 content) to the Android device.
+//
+// Args[0]: device_id (string)
+// Args[1]: local_path (string) - path on the Yao server, OR empty if content is provided
+// Args[2]: remote_path (string) - destination path on the device
+// Args[3]: content_base64 (string, optional) - base64-encoded content to push directly
+func PushHandler(proc *process.Process) interface{} {
+	deviceID, err := extractDeviceID(proc, 0)
+	if err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+
+	localPath := proc.ArgsString(1)
+	remotePath := proc.ArgsString(2)
+	contentB64 := proc.ArgsString(3)
+
+	if remotePath == "" {
+		return map[string]any{"error": "remote_path is required"}
+	}
+
+	if _, err := getAndroidNode(deviceID); err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+
+	res, ok := tai.GetResources(deviceID)
+	if !ok {
+		return map[string]any{"error": fmt.Sprintf("device %q: no connection resources", deviceID)}
+	}
+	if res.Volume == nil {
+		return map[string]any{"error": fmt.Sprintf("device %q: volume not enabled", deviceID)}
+	}
+
+	var data []byte
+	if contentB64 != "" {
+		data, err = base64.StdEncoding.DecodeString(contentB64)
+		if err != nil {
+			return map[string]any{"error": fmt.Sprintf("invalid base64 content: %v", err)}
+		}
+	} else if localPath != "" {
+		data, err = os.ReadFile(localPath)
+		if err != nil {
+			return map[string]any{"error": fmt.Sprintf("read local file: %v", err)}
+		}
+	} else {
+		return map[string]any{"error": "either local_path or content_base64 is required"}
+	}
+
+	ctx := context.Background()
+	if proc.Context != nil {
+		ctx = proc.Context
+	}
+
+	if err := res.Volume.WriteFile(ctx, deviceID, remotePath, data, 0644); err != nil {
+		return map[string]any{"error": fmt.Sprintf("write to device: %v", err)}
+	}
+
+	return map[string]any{
+		"success":     true,
+		"remote_path": remotePath,
+		"bytes":       len(data),
+	}
+}

--- a/tools/mobile/push_schema.json
+++ b/tools/mobile/push_schema.json
@@ -1,0 +1,28 @@
+{
+  "name": "mobile_push",
+  "description": "Push a file to a connected Android device. Provide either a local_path (file on the Yao server) or content_base64 (base64-encoded data).",
+  "process": "tools.mobile_push",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "device_id": {
+        "type": "string",
+        "description": "The Tai ID of the target Android device (from mobile_list)"
+      },
+      "local_path": {
+        "type": "string",
+        "description": "Path to a file on the Yao server to push (mutually exclusive with content_base64)"
+      },
+      "remote_path": {
+        "type": "string",
+        "description": "Destination file path on the Android device"
+      },
+      "content_base64": {
+        "type": "string",
+        "description": "Base64-encoded file content to push directly (mutually exclusive with local_path)"
+      }
+    },
+    "required": ["device_id", "remote_path"]
+  },
+  "x-process-args": ["$args.device_id", "$args.local_path", "$args.remote_path", "$args.content_base64"]
+}

--- a/tools/mobile/screenshot.go
+++ b/tools/mobile/screenshot.go
@@ -1,0 +1,61 @@
+package mobile
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"strings"
+
+	"github.com/yaoapp/gou/process"
+)
+
+//go:embed screenshot_schema.json
+var ScreenshotSchemaJSON []byte
+
+const screenshotPath = "/sdcard/tai_screen.png"
+
+// ScreenshotHandler is the tools.mobile_screenshot process handler.
+// Takes a screenshot on the Android device and returns it as a base64-encoded PNG.
+//
+// Args[0]: device_id (string)
+func ScreenshotHandler(proc *process.Process) interface{} {
+	deviceID, err := extractDeviceID(proc, 0)
+	if err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+
+	if _, err := getAndroidNode(deviceID); err != nil {
+		return map[string]any{"error": err.Error()}
+	}
+
+	ctx := context.Background()
+	if proc.Context != nil {
+		ctx = proc.Context
+	}
+
+	captureCmd := fmt.Sprintf("screencap -p %s", screenshotPath)
+	_, stderr, exitCode, err := execOnDevice(ctx, deviceID, captureCmd)
+	if err != nil || exitCode != 0 {
+		return map[string]any{
+			"error": fmt.Sprintf("screencap failed (exit=%d): %s %v", exitCode, strings.TrimSpace(stderr), err),
+		}
+	}
+
+	encodeCmd := fmt.Sprintf("base64 %s | tr -d '\\n'", screenshotPath)
+	stdout, stderr, exitCode, err := execOnDevice(ctx, deviceID, encodeCmd)
+	if err != nil || exitCode != 0 {
+		return map[string]any{
+			"error": fmt.Sprintf("base64 encode failed (exit=%d): %s %v", exitCode, strings.TrimSpace(stderr), err),
+		}
+	}
+
+	// Cleanup temp file
+	go func() {
+		execOnDevice(context.Background(), deviceID, "rm -f "+screenshotPath)
+	}()
+
+	return map[string]any{
+		"image_base64": strings.TrimSpace(stdout),
+		"format":       "png",
+	}
+}

--- a/tools/mobile/screenshot_schema.json
+++ b/tools/mobile/screenshot_schema.json
@@ -1,0 +1,16 @@
+{
+  "name": "mobile_screenshot",
+  "description": "Capture a screenshot on the Android device and return it as a base64-encoded PNG image.",
+  "process": "tools.mobile_screenshot",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "device_id": {
+        "type": "string",
+        "description": "The Tai ID of the target Android device (from mobile_list)"
+      }
+    },
+    "required": ["device_id"]
+  },
+  "x-process-args": ["$args.device_id"]
+}

--- a/tools/prompts/system-tools.md
+++ b/tools/prompts/system-tools.md
@@ -106,8 +106,14 @@ You have access to Yao system tools via the `tai` command in bash.
 | `clip_write`             | yao-clip      | Store a content clip (screenshot, DOM, structured data). Returns clip ID |
 | `clip_read`              | yao-clip      | Read a stored clip by ID. Use when you see `<Mention type="clip">` tags |
 | `clip_list`              | yao-clip      | List all available clips in the current session     |
+| `mobile_list`            | yao-mobile    | List all online Android devices connected via Tai Link |
+| `mobile_exec`            | yao-mobile    | Execute a shell command on an Android device        |
+| `mobile_screenshot`      | yao-mobile    | Capture a screenshot and return base64 PNG          |
+| `mobile_info`            | yao-mobile    | Get detailed device info (OS, arch, capabilities)   |
+| `mobile_push`            | yao-mobile    | Push a file to an Android device                    |
+| `mobile_pull`            | yao-mobile    | Pull a file from an Android device                  |
 
-The system skills (`yao-web`, `yao-process`, `yao-doc`, `yao-image`, `yao-agent`, `yao-secret`, `yao-robot`, `yao-workspace`, `yao-clip`) in `$HOME/.claude/skills/` are **auto-discovered** — they contain detailed parameter docs and workflow guidance. You do not need to manually read them; they are loaded automatically when your task matches their description.
+The system skills (`yao-web`, `yao-process`, `yao-doc`, `yao-image`, `yao-agent`, `yao-secret`, `yao-robot`, `yao-workspace`, `yao-clip`, `yao-mobile`) in `$HOME/.claude/skills/` are **auto-discovered** — they contain detailed parameter docs and workflow guidance. You do not need to manually read them; they are loaded automatically when your task matches their description.
 
 ## Mention Tags
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -14,6 +14,7 @@ import (
 	"github.com/yaoapp/yao/tools/docs"
 	"github.com/yaoapp/yao/tools/image"
 	toolinbox "github.com/yaoapp/yao/tools/inbox"
+	"github.com/yaoapp/yao/tools/mobile"
 	"github.com/yaoapp/yao/tools/proc"
 	"github.com/yaoapp/yao/tools/robot"
 	"github.com/yaoapp/yao/tools/secret"
@@ -52,6 +53,9 @@ var mcpClipDSL []byte
 
 //go:embed mcps/kanban.json
 var mcpKanbanDSL []byte
+
+//go:embed mcps/mobile.json
+var mcpMobileDSL []byte
 
 func init() {
 	process.RegisterGroup("tools", map[string]process.Handler{
@@ -105,6 +109,13 @@ func init() {
 
 		"inbox_list": toolinbox.ListHandler,
 		"inbox_read": toolinbox.ReadHandler,
+
+		"mobile_list":       mobile.ListHandler,
+		"mobile_exec":       mobile.ExecHandler,
+		"mobile_screenshot": mobile.ScreenshotHandler,
+		"mobile_info":       mobile.InfoHandler,
+		"mobile_push":       mobile.PushHandler,
+		"mobile_pull":       mobile.PullHandler,
 	})
 
 	registerMCPServer(mcpWebDSL, "yao-web",
@@ -135,6 +146,9 @@ func init() {
 		tooltask.ListSchemaJSON, tooltask.CreateSchemaJSON, tooltask.MoveSchemaJSON,
 		toolboard.ListSchemaJSON, toolboard.CreateSchemaJSON,
 		toolinbox.ListSchemaJSON, toolinbox.ReadSchemaJSON)
+	registerMCPServer(mcpMobileDSL, "yao-mobile",
+		mobile.ListSchemaJSON, mobile.ExecSchemaJSON, mobile.ScreenshotSchemaJSON,
+		mobile.InfoSchemaJSON, mobile.PushSchemaJSON, mobile.PullSchemaJSON)
 }
 
 func registerMCPServer(dsl []byte, id string, schemas ...[]byte) {


### PR DESCRIPTION
Introduced new mobile commands including `mobile_list`, `mobile_exec`, `mobile_screenshot`, `mobile_info`, `mobile_push`, and `mobile_pull` to enhance mobile device management capabilities. Updated the system tools documentation to reflect these additions, ensuring users have access to the latest functionalities.