### PR TITLE
feat(webproxy): implement proxy authentication cookie and streamline …

### DIFF
--- a/tai/webproxy/auth.go
+++ b/tai/webproxy/auth.go
@@ -6,15 +6,16 @@ import (
 	"strings"
 
 	"github.com/yaoapp/yao/openapi/oauth"
-	"github.com/yaoapp/yao/openapi/response"
 )
 
-// authMiddleware wraps an http.Handler with JWT cookie/bearer token authentication.
+const proxyAuthCookie = "_yao_proxy"
+
+// authMiddleware wraps an http.Handler with JWT cookie authentication.
+// Uses a dedicated cookie (_yao_proxy) to avoid conflicts with target app auth.
 func authMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		svc := oauth.OAuth
 		if svc == nil {
-			// OAuth not initialized — allow through (dev/testing mode)
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -36,29 +37,25 @@ func authMiddleware(next http.Handler) http.Handler {
 }
 
 func extractToken(r *http.Request) string {
-	// Try Authorization header first
-	if auth := r.Header.Get("Authorization"); auth != "" {
-		return strings.TrimPrefix(auth, "Bearer ")
-	}
-
-	// Try access_token cookie (both with and without __Host- prefix)
-	// Note: net/http does NOT URL-decode cookie values (unlike Gin's c.Cookie()),
-	// so we must manually decode to handle "Bearer+" → "Bearer ".
-	cookieName := response.GetCookieName("access_token")
-	if c, err := r.Cookie(cookieName); err == nil && c.Value != "" {
+	if c, err := r.Cookie(proxyAuthCookie); err == nil && c.Value != "" {
 		return decodeBearerCookie(c.Value)
 	}
-
-	// Fallback: plain cookie name without prefix
-	if c, err := r.Cookie("access_token"); err == nil && c.Value != "" {
-		return decodeBearerCookie(c.Value)
-	}
-
 	return ""
 }
 
+// stripProxyCookie removes the proxy's own auth cookie from the request
+// before forwarding to the target application.
+func stripProxyCookie(r *http.Request) {
+	cookies := r.Cookies()
+	r.Header.Del("Cookie")
+	for _, c := range cookies {
+		if c.Name != proxyAuthCookie {
+			r.AddCookie(c)
+		}
+	}
+}
+
 func decodeBearerCookie(raw string) string {
-	// URL-decode first (handles "Bearer+" → "Bearer ")
 	decoded, err := url.QueryUnescape(raw)
 	if err != nil {
 		decoded = raw

--- a/tai/webproxy/binding.go
+++ b/tai/webproxy/binding.go
@@ -101,7 +101,7 @@ func (b *Binding) Stop() {
 	b.Cancel()
 }
 
-// handleAuth sets an access_token cookie and redirects to the target service.
+// handleAuth sets the proxy auth cookie and redirects to the target service.
 func (b *Binding) handleAuth(w http.ResponseWriter, r *http.Request) {
 	token := r.URL.Query().Get("token")
 	if token == "" {
@@ -109,7 +109,7 @@ func (b *Binding) handleAuth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	http.SetCookie(w, &http.Cookie{
-		Name:     "access_token",
+		Name:     proxyAuthCookie,
 		Value:    url.QueryEscape("Bearer " + token),
 		Path:     "/",
 		HttpOnly: true,
@@ -138,6 +138,7 @@ func (b *Binding) buildHandler() http.Handler {
 				req.URL.Scheme = target.Scheme
 				req.URL.Host = target.Host
 				req.Host = r.Host
+				stripProxyCookie(req)
 			},
 			FlushInterval: -1,
 		}
@@ -182,6 +183,7 @@ func (b *Binding) handleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 	defer clientConn.Close()
 
+	stripProxyCookie(r)
 	if err := r.Write(targetConn); err != nil {
 		return
 	}


### PR DESCRIPTION
…request handling

Introduced a dedicated proxy authentication cookie (_yao_proxy) for JWT authentication, replacing the previous access_token cookie. Updated the authMiddleware to utilize this new cookie and added a stripProxyCookie function to remove the proxy's auth cookie before forwarding requests to the target application. Enhanced the handleAuth method to set the proxy auth cookie during authentication, ensuring clearer separation of authentication mechanisms.