### PR TITLE
feat(auth): implement server key authentication for cloud nodes

### DIFF
--- a/agent/sandbox/v2/node_selector_unit_test.go
+++ b/agent/sandbox/v2/node_selector_unit_test.go
@@ -314,6 +314,32 @@ func TestSelectNode_S13_GroupPriority(t *testing.T) {
 	}
 }
 
+func cloudNode(id string, runners []string, canBox, canHost bool) sandboxv2.NodeCandidate {
+	return sandboxv2.NodeCandidate{
+		ID: id, IsLocal: false, Runners: runners,
+		CanBox: canBox, CanHost: canHost, OS: "linux", Arch: "amd64",
+	}
+}
+
+func TestSelectNode_CloudInGroupBox(t *testing.T) {
+	testprepare.PrepareUnit(t)
+	nodes := []sandboxv2.NodeCandidate{
+		localNode([]string{"claude"}, false, true),
+		cloudNode("tai-cloud", []string{"claude"}, true, false),
+	}
+	sel, err := sandboxv2.SelectNode(nodes, &sandboxv2.SelectionCriteria{
+		Preferred: "claude",
+		Allowed:   []string{"claude"},
+		Image:     "ubuntu",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sel.NodeID != "tai-cloud" || sel.Mode != "box" || sel.Runner != "claude" {
+		t.Errorf("got node=%q runner=%q mode=%q, want tai-cloud/claude/box (cloud Docker node in groupBox)", sel.NodeID, sel.Runner, sel.Mode)
+	}
+}
+
 func TestSelectNode_Filter_Arch(t *testing.T) {
 	testprepare.PrepareUnit(t)
 	nodes := []sandboxv2.NodeCandidate{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -245,6 +245,7 @@ func init() {
 		docCmd,
 		tokenCmd,
 		upgradeCmd,
+		serverKeyCmd,
 	)
 	// rootCmd.SetHelpCommand(helpCmd)
 	rootCmd.PersistentFlags().StringVarP(&appPath, "app", "a", "", L("Application directory"))

--- a/cmd/serverkey.go
+++ b/cmd/serverkey.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+	"github.com/yaoapp/yao/config"
+	"github.com/yaoapp/yao/engine"
+	"github.com/yaoapp/yao/setting"
+)
+
+var serverKeyName string
+var serverKeyTTL string
+
+var serverKeyCmd = &cobra.Command{
+	Use:   "server-key",
+	Short: "Server Key management for cloud Tai nodes",
+	Long:  "Create, list, and revoke server keys (yao-sk: prefix) for cloud Tai node authentication",
+	CompletionOptions: cobra.CompletionOptions{
+		DisableDefaultCmd: true,
+	},
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Help()
+	},
+}
+
+var serverKeyCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new server key",
+	Long:  "Create a new server key for cloud Tai node authentication. The plaintext key is shown once.",
+	Run: func(cmd *cobra.Command, args []string) {
+		Boot()
+		cfg := config.Conf
+		engine.Load(cfg, engine.LoadOption{})
+
+		if serverKeyName == "" {
+			serverKeyName = "cloud-node"
+		}
+
+		var opts []time.Duration
+		if serverKeyTTL != "" {
+			d, err := time.ParseDuration(serverKeyTTL)
+			if err != nil {
+				color.Red("Invalid TTL %q: %v", serverKeyTTL, err)
+				os.Exit(1)
+			}
+			opts = append(opts, d)
+		}
+
+		plainKey, keyID, err := setting.CreateServerKey(serverKeyName, opts...)
+		if err != nil {
+			color.Red("Failed to create server key: %v", err)
+			os.Exit(1)
+		}
+		setting.Global.Flush()
+
+		fmt.Println()
+		color.Green("  Server key created successfully")
+		fmt.Println()
+		color.White("  Key ID:  %s", keyID)
+		color.White("  Name:    %s", serverKeyName)
+		if serverKeyTTL != "" {
+			color.White("  TTL:     %s", serverKeyTTL)
+		}
+		color.Yellow("  Key:     %s", plainKey)
+		fmt.Println()
+		color.Red("  ⚠ Save this key now. It will not be shown again.")
+		fmt.Println()
+	},
+}
+
+var serverKeyListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List all server keys",
+	Run: func(cmd *cobra.Command, args []string) {
+		Boot()
+		cfg := config.Conf
+		engine.Load(cfg, engine.LoadOption{})
+
+		keys, err := setting.ListServerKeys()
+		if err != nil {
+			color.Red("Failed to list server keys: %v", err)
+			os.Exit(1)
+		}
+
+		if len(keys) == 0 {
+			color.White("  No server keys found")
+			return
+		}
+
+		fmt.Println()
+		for _, k := range keys {
+			status := color.GreenString("active")
+			if k.Revoked {
+				status = color.RedString("revoked")
+			}
+			color.White("  %s  %s  [%s]  created: %s", k.ID, k.Name, status, k.CreatedAt)
+			if k.ExpiresAt != "" {
+				color.White("    expires: %s", k.ExpiresAt)
+			}
+			if k.LastUsed != "" {
+				color.White("    last used: %s", k.LastUsed)
+			}
+		}
+		fmt.Println()
+	},
+}
+
+var serverKeyRevokeCmd = &cobra.Command{
+	Use:   "revoke <key-id>",
+	Short: "Revoke a server key",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		Boot()
+		cfg := config.Conf
+		engine.Load(cfg, engine.LoadOption{})
+
+		keyID := args[0]
+		if err := setting.RevokeServerKey(keyID); err != nil {
+			color.Red("Failed to revoke server key: %v", err)
+			os.Exit(1)
+		}
+		setting.Global.Flush()
+
+		color.Green("  Server key %s revoked", keyID)
+	},
+}
+
+func init() {
+	serverKeyCreateCmd.Flags().StringVar(&serverKeyName, "name", "", "Name/label for the server key")
+	serverKeyCreateCmd.Flags().StringVar(&serverKeyTTL, "ttl", "", "Time-to-live (e.g. 720h for 30 days; empty = never expires)")
+	serverKeyCmd.AddCommand(serverKeyCreateCmd)
+	serverKeyCmd.AddCommand(serverKeyListCmd)
+	serverKeyCmd.AddCommand(serverKeyRevokeCmd)
+}

--- a/grpc/auth/guard.go
+++ b/grpc/auth/guard.go
@@ -12,6 +12,7 @@ import (
 	"github.com/yaoapp/yao/openapi/oauth"
 	"github.com/yaoapp/yao/openapi/oauth/acl"
 	"github.com/yaoapp/yao/openapi/oauth/types"
+	"github.com/yaoapp/yao/setting"
 )
 
 const (
@@ -84,6 +85,17 @@ func authenticate(ctx context.Context, fullMethod string, req interface{}) (cont
 	bearer := extractBearer(md)
 	if bearer == "" {
 		return ctx, status.Error(codes.Unauthenticated, "missing authorization token")
+	}
+
+	// Server Key authentication — yao-sk: prefixed tokens bypass OAuth.
+	if setting.IsServerKeyFormat(bearer) {
+		keyID, err := setting.ValidateServerKey(bearer)
+		if err != nil {
+			return ctx, status.Error(codes.Unauthenticated, err.Error())
+		}
+		setting.UpdateServerKeyLastUsed(keyID)
+		info := &types.AuthorizedInfo{Platform: true, ClientID: keyID}
+		return WithAuthorizedInfo(ctx, info), nil
 	}
 
 	result, err := svc.AuthenticateToken(oauth.AuthInput{

--- a/grpc/auth/guard_test.go
+++ b/grpc/auth/guard_test.go
@@ -5,12 +5,15 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/yaoapp/yao/grpc/pb"
 	"github.com/yaoapp/yao/grpc/tests/testutils"
+	"github.com/yaoapp/yao/setting"
+	"github.com/yaoapp/yao/tai/registry"
 	"github.com/yaoapp/yao/tai/tunnel/taipb"
 )
 
@@ -258,4 +261,68 @@ func TestAuth_TaiTunnel_Register_ExpiredToken(t *testing.T) {
 	assert.Error(t, err)
 	st, _ := status.FromError(err)
 	assert.Equal(t, codes.Unauthenticated, st.Code())
+}
+
+func TestAuthenticate_ServerKey(t *testing.T) {
+	conn := testutils.Prepare(t)
+	defer testutils.Clean()
+
+	require.NoError(t, setting.Init())
+
+	plainKey, keyID, err := setting.CreateServerKey("grpc-auth-test")
+	require.NoError(t, err)
+
+	client := taipb.NewTaiTunnelClient(conn)
+	ctx := testutils.WithToken(context.Background(), plainKey)
+
+	stream, err := client.Register(ctx)
+	require.NoError(t, err)
+
+	err = stream.Send(&taipb.TunnelControl{
+		Type: "register", NodeId: "sk-test-node", MachineId: "sk-test-machine",
+	})
+	require.NoError(t, err)
+
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+	assert.Equal(t, "registered", resp.Type)
+	assert.NotEmpty(t, resp.TaiId)
+
+	node, ok := registry.Global().Get(resp.TaiId)
+	require.True(t, ok)
+	assert.True(t, node.Auth.Platform, "server key auth should set Platform=true")
+	assert.Equal(t, keyID, node.Auth.ClientID)
+	assert.Equal(t, "cloud", node.Mode)
+	stream.CloseSend()
+}
+
+func TestAuthenticate_ServerKey_Invalid(t *testing.T) {
+	conn := testutils.Prepare(t)
+	defer testutils.Clean()
+
+	client := testutils.NewClient(conn)
+	ctx := testutils.WithToken(context.Background(), "yao-sk:invalid-key")
+
+	_, err := client.Run(ctx, &pb.RunRequest{Process: "utils.app.Ping"})
+	require.Error(t, err)
+
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Unauthenticated, st.Code())
+	assert.Contains(t, st.Message(), "invalid server key")
+}
+
+func TestAuthenticate_OAuthUnchanged(t *testing.T) {
+	conn := testutils.Prepare(t)
+	defer testutils.Clean()
+
+	client := testutils.NewClient(conn)
+	token := testutils.ObtainAccessToken(t, "grpc:run")
+	ctx := testutils.WithToken(context.Background(), token)
+
+	_, err := client.Run(ctx, &pb.RunRequest{Process: "utils.app.Ping"})
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.NotEqual(t, codes.Unauthenticated, st.Code())
+	assert.NotContains(t, st.Message(), "invalid server key")
 }

--- a/openapi/agent/runners.go
+++ b/openapi/agent/runners.go
@@ -5,7 +5,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 	sandboxv2 "github.com/yaoapp/yao/agent/sandbox/v2"
+	"github.com/yaoapp/yao/openapi/oauth/authorized"
+	oauthTypes "github.com/yaoapp/yao/openapi/oauth/types"
 	"github.com/yaoapp/yao/tai/registry"
+	taitypes "github.com/yaoapp/yao/tai/types"
 )
 
 var runnerDescriptions = map[string]string{
@@ -26,7 +29,8 @@ type RunnerInfo struct {
 // ListRunners returns the list of supported runners and their availability.
 // GET /api/v1/agent/runners
 func ListRunners(c *gin.Context) {
-	nodesByRunner := runnerNodes()
+	authInfo := authorized.GetInfo(c)
+	nodesByRunner := runnerNodes(authInfo)
 
 	var runners []RunnerInfo
 	for _, name := range sandboxv2.SupportedRunners {
@@ -45,7 +49,7 @@ func ListRunners(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"runners": runners})
 }
 
-func runnerNodes() map[string][]string {
+func runnerNodes(authInfo *oauthTypes.AuthorizedInfo) map[string][]string {
 	result := map[string][]string{}
 	reg := registry.Global()
 	if reg == nil {
@@ -54,6 +58,9 @@ func runnerNodes() map[string][]string {
 
 	for _, node := range reg.List() {
 		if node.Status != "online" && node.Status != "" {
+			continue
+		}
+		if !taitypes.IsPublicNode(node.Mode) && !runnerNodeOwnedBy(&node, authInfo) {
 			continue
 		}
 		runners := node.Capabilities.Runners
@@ -65,4 +72,17 @@ func runnerNodes() map[string][]string {
 		}
 	}
 	return result
+}
+
+func runnerNodeOwnedBy(snap *taitypes.NodeMeta, authInfo *oauthTypes.AuthorizedInfo) bool {
+	if authInfo == nil {
+		return true
+	}
+	if authInfo.TeamID != "" {
+		return snap.Auth.TeamID == authInfo.TeamID
+	}
+	if authInfo.UserID != "" {
+		return snap.Auth.TeamID == "" && snap.Auth.UserID == authInfo.UserID
+	}
+	return true
 }

--- a/openapi/agent/runners_test.go
+++ b/openapi/agent/runners_test.go
@@ -1,0 +1,106 @@
+package agent_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaoapp/yao/openapi/agent"
+	"github.com/yaoapp/yao/tai/registry"
+	taitypes "github.com/yaoapp/yao/tai/types"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func setupMockRegistry(t *testing.T) func() {
+	t.Helper()
+	reg := registry.NewForTest()
+	registry.SetGlobalForTest(reg)
+	return func() {
+		registry.SetGlobalForTest(nil)
+	}
+}
+
+func setAuthContext(c *gin.Context, userID, teamID string) {
+	c.Set("__subject", "test-subject")
+	c.Set("__client_id", "test-client")
+	c.Set("__scope", "openid profile")
+	if userID != "" {
+		c.Set("__user_id", userID)
+	}
+	if teamID != "" {
+		c.Set("__team_id", teamID)
+	}
+}
+
+func listRunners(t *testing.T, userID, teamID string) map[string][]string {
+	t.Helper()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/agent/runners", nil)
+	setAuthContext(c, userID, teamID)
+
+	agent.ListRunners(c)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var resp struct {
+		Runners []struct {
+			Name      string   `json:"name"`
+			Available bool     `json:"available"`
+			Nodes     []string `json:"nodes"`
+		} `json:"runners"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	nodesByRunner := make(map[string][]string, len(resp.Runners))
+	for _, r := range resp.Runners {
+		nodesByRunner[r.Name] = r.Nodes
+	}
+	return nodesByRunner
+}
+
+func runnerNodes(nodesByRunner map[string][]string, runner string) []string {
+	nodes, ok := nodesByRunner[runner]
+	if !ok {
+		return nil
+	}
+	return nodes
+}
+
+func TestRunnersACL(t *testing.T) {
+	teardown := setupMockRegistry(t)
+	defer teardown()
+
+	reg := registry.Global()
+	reg.Register(&registry.TaiNode{
+		TaiID: "tai-cloud",
+		Mode:  "cloud",
+		Capabilities: taitypes.Capabilities{
+			Runners: []string{"claude"},
+		},
+	})
+	reg.Register(&registry.TaiNode{
+		TaiID: "tai-tunnel",
+		Mode:  "tunnel",
+		Auth:  taitypes.AuthInfo{UserID: "user-owner"},
+		Capabilities: taitypes.Capabilities{
+			Runners: []string{"claude"},
+		},
+	})
+
+	ownerRunners := listRunners(t, "user-owner", "")
+	assert.Contains(t, runnerNodes(ownerRunners, "claude"), "tai-cloud")
+	assert.Contains(t, runnerNodes(ownerRunners, "claude"), "tai-tunnel")
+
+	otherRunners := listRunners(t, "user-other", "")
+	assert.Contains(t, runnerNodes(otherRunners, "claude"), "tai-cloud")
+	assert.NotContains(t, runnerNodes(otherRunners, "claude"), "tai-tunnel")
+}

--- a/openapi/agent/task/system.go
+++ b/openapi/agent/task/system.go
@@ -12,6 +12,8 @@ import (
 	"github.com/yaoapp/yao/openapi/oauth/authorized"
 	"github.com/yaoapp/yao/openapi/response"
 	sandbox "github.com/yaoapp/yao/sandbox/v2"
+	"github.com/yaoapp/yao/tai/registry"
+	taitypes "github.com/yaoapp/yao/tai/types"
 )
 
 // handleTaskPortsGet returns listening ports for the sandbox associated with this task.
@@ -142,7 +144,8 @@ func resolveComputer(c *gin.Context) (sandbox.Computer, error) {
 
 	isHostMode := !ast.HasSandboxV2() || cfg.Computer.Image == ""
 	if isHostMode {
-		host, err := mgr.Host(c.Request.Context(), "local")
+		nodeID := resolveHostNode()
+		host, err := mgr.Host(c.Request.Context(), nodeID)
 		if err != nil {
 			respondError(c, http.StatusInternalServerError, fmt.Errorf("host mode unavailable: %w", err))
 			return nil, err
@@ -173,4 +176,19 @@ func resolveComputer(c *gin.Context) (sandbox.Computer, error) {
 	}
 
 	return box, nil
+}
+
+// resolveHostNode selects the first public node that supports HostExec and is online.
+// Falls back to "local" if no suitable node is found.
+func resolveHostNode() string {
+	reg := registry.Global()
+	if reg == nil {
+		return "local"
+	}
+	for _, n := range reg.List() {
+		if taitypes.IsPublicNode(n.Mode) && n.Capabilities.HostExec && n.Status == "online" {
+			return n.TaiID
+		}
+	}
+	return "local"
 }

--- a/openapi/agent/task/system_test.go
+++ b/openapi/agent/task/system_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	sandbox "github.com/yaoapp/yao/sandbox/v2"
+	"github.com/yaoapp/yao/tai/registry"
+	taitypes "github.com/yaoapp/yao/tai/types"
 )
 
 func TestPortInfoJSONFormat(t *testing.T) {
@@ -216,4 +218,67 @@ func TestSandboxNotRunningResponse(t *testing.T) {
 	if parsed["status"] != "sandbox_not_running" {
 		t.Errorf("status: got %v", parsed["status"])
 	}
+}
+
+func setupMockRegistry(t *testing.T) func() {
+	t.Helper()
+	reg := registry.NewForTest()
+	registry.SetGlobalForTest(reg)
+	return func() {
+		registry.SetGlobalForTest(nil)
+	}
+}
+
+func TestResolveHostNode(t *testing.T) {
+	t.Run("selects online public node with HostExec", func(t *testing.T) {
+		teardown := setupMockRegistry(t)
+		defer teardown()
+
+		reg := registry.Global()
+		reg.Register(&registry.TaiNode{
+			TaiID:        "tai-tunnel",
+			Mode:         "tunnel",
+			Capabilities: taitypes.Capabilities{HostExec: true},
+		})
+		reg.Register(&registry.TaiNode{
+			TaiID:        "tai-cloud",
+			Mode:         "cloud",
+			Capabilities: taitypes.Capabilities{HostExec: true},
+		})
+
+		got := resolveHostNode()
+		if got != "tai-cloud" {
+			t.Errorf("resolveHostNode() = %q, want tai-cloud", got)
+		}
+	})
+
+	t.Run("falls back to local when no suitable public node", func(t *testing.T) {
+		teardown := setupMockRegistry(t)
+		defer teardown()
+
+		reg := registry.Global()
+		reg.Register(&registry.TaiNode{
+			TaiID:        "tai-tunnel",
+			Mode:         "tunnel",
+			Capabilities: taitypes.Capabilities{HostExec: true},
+		})
+		reg.Register(&registry.TaiNode{
+			TaiID:        "tai-cloud",
+			Mode:         "cloud",
+			Capabilities: taitypes.Capabilities{HostExec: false},
+		})
+
+		got := resolveHostNode()
+		if got != "local" {
+			t.Errorf("resolveHostNode() = %q, want local", got)
+		}
+	})
+
+	t.Run("falls back to local when registry is nil", func(t *testing.T) {
+		registry.SetGlobalForTest(nil)
+		got := resolveHostNode()
+		if got != "local" {
+			t.Errorf("resolveHostNode() = %q, want local", got)
+		}
+	})
 }

--- a/openapi/computer/computer.go
+++ b/openapi/computer/computer.go
@@ -89,7 +89,7 @@ func handleOptions(c *gin.Context) {
 	if kindFilter == "" || kindFilter == "host" {
 		for i := range snaps {
 			s := &snaps[i]
-			if s.Mode != "local" && !nodeOwnedBy(s, authInfo) {
+			if !taitypes.IsPublicNode(s.Mode) && !nodeOwnedBy(s, authInfo) {
 				continue
 			}
 			if !s.Capabilities.HostExec {
@@ -106,7 +106,7 @@ func handleOptions(c *gin.Context) {
 	if kindFilter == "" || kindFilter == "node" {
 		for i := range snaps {
 			s := &snaps[i]
-			if s.Mode != "local" && !nodeOwnedBy(s, authInfo) {
+			if !taitypes.IsPublicNode(s.Mode) && !nodeOwnedBy(s, authInfo) {
 				continue
 			}
 			hasRuntime := s.Capabilities.Docker || s.Capabilities.K8s

--- a/openapi/file/bundle.go
+++ b/openapi/file/bundle.go
@@ -93,7 +93,7 @@ func bundle(c *gin.Context) {
 
 func resolveFile(c *gin.Context, authInfo *types.AuthorizedInfo, fileURI string) (io.Reader, error) {
 	if strings.HasPrefix(fileURI, "workspace://") {
-		return resolveWorkspaceFile(c, fileURI)
+		return resolveWorkspaceFile(c, authInfo, fileURI)
 	}
 	if strings.HasPrefix(fileURI, "http://") || strings.HasPrefix(fileURI, "https://") {
 		return resolveHTTPFile(fileURI)
@@ -135,7 +135,7 @@ func resolveWrapperFile(c *gin.Context, authInfo *types.AuthorizedInfo, fileURI 
 	return bytes.NewReader(data), nil
 }
 
-func resolveWorkspaceFile(c *gin.Context, fileURI string) (io.Reader, error) {
+func resolveWorkspaceFile(c *gin.Context, authInfo *types.AuthorizedInfo, fileURI string) (io.Reader, error) {
 	rest := strings.TrimPrefix(fileURI, "workspace://")
 	idx := strings.Index(rest, "/")
 	if idx < 0 {
@@ -149,12 +149,32 @@ func resolveWorkspaceFile(c *gin.Context, fileURI string) (io.Reader, error) {
 		return nil, fmt.Errorf("workspace service not available")
 	}
 
+	wsInfo, err := m.Get(context.Background(), wsID)
+	if err != nil {
+		return nil, fmt.Errorf("workspace not found: %w", err)
+	}
+
+	owner := resolveOwner(authInfo)
+	if wsInfo.Owner != "" && wsInfo.Owner != owner {
+		return nil, fmt.Errorf("no permission to access workspace %q", wsID)
+	}
+
 	data, err := m.ReadFile(context.Background(), wsID, filePath)
 	if err != nil {
 		return nil, fmt.Errorf("workspace file read failed: %w", err)
 	}
 
 	return bytes.NewReader(data), nil
+}
+
+func resolveOwner(authInfo *types.AuthorizedInfo) string {
+	if authInfo != nil && authInfo.TeamID != "" {
+		return authInfo.TeamID
+	}
+	if authInfo != nil {
+		return authInfo.UserID
+	}
+	return ""
 }
 
 func resolveHTTPFile(fileURL string) (io.Reader, error) {

--- a/openapi/file/bundle_test.go
+++ b/openapi/file/bundle_test.go
@@ -1,0 +1,28 @@
+package file_test
+
+import (
+	"testing"
+
+	"github.com/yaoapp/yao/openapi/file"
+	types "github.com/yaoapp/yao/openapi/oauth/types"
+)
+
+func TestBundleWorkspaceOwnerCheck(t *testing.T) {
+	tests := []struct {
+		name string
+		info *types.AuthorizedInfo
+		want string
+	}{
+		{"nil", nil, ""},
+		{"team", &types.AuthorizedInfo{TeamID: "team-1", UserID: "user-1"}, "team-1"},
+		{"user only", &types.AuthorizedInfo{UserID: "user-1"}, "user-1"},
+		{"empty", &types.AuthorizedInfo{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := file.ResolveOwner(tt.info); got != tt.want {
+				t.Errorf("ResolveOwner() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/openapi/file/export_test.go
+++ b/openapi/file/export_test.go
@@ -1,0 +1,4 @@
+package file
+
+// ResolveOwner exposes resolveOwner for black-box testing.
+var ResolveOwner = resolveOwner

--- a/openapi/nodes/nodes.go
+++ b/openapi/nodes/nodes.go
@@ -103,7 +103,7 @@ func handleList(c *gin.Context) {
 	result := make([]nodeResponse, 0, len(snaps))
 	for i := range snaps {
 		s := &snaps[i]
-		if s.Mode != "local" && !nodeOwnedBy(s, authInfo) {
+		if !taitypes.IsPublicNode(s.Mode) && !nodeOwnedBy(s, authInfo) {
 			continue
 		}
 		result = append(result, snapToResponse(*s))
@@ -126,7 +126,7 @@ func handleGet(c *gin.Context) {
 	}
 
 	authInfo := authorized.GetInfo(c)
-	if snap.Mode != "local" && !nodeOwnedBy(snap, authInfo) {
+	if !taitypes.IsPublicNode(snap.Mode) && !nodeOwnedBy(snap, authInfo) {
 		c.JSON(http.StatusForbidden, gin.H{"error": "no permission to access this node"})
 		return
 	}

--- a/openapi/nodes/nodes_test.go
+++ b/openapi/nodes/nodes_test.go
@@ -1,0 +1,137 @@
+package nodes_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/yaoapp/yao/openapi/nodes"
+	"github.com/yaoapp/yao/tai/registry"
+	taitypes "github.com/yaoapp/yao/tai/types"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func setupMockRegistry(t *testing.T) func() {
+	t.Helper()
+	reg := registry.NewForTest()
+	registry.SetGlobalForTest(reg)
+	return func() {
+		registry.SetGlobalForTest(nil)
+	}
+}
+
+func registerCloudAndTunnelNodes(reg *registry.Registry) {
+	reg.Register(&registry.TaiNode{
+		TaiID: "tai-cloud",
+		Mode:  "cloud",
+	})
+	reg.Register(&registry.TaiNode{
+		TaiID: "tai-tunnel",
+		Mode:  "tunnel",
+		Auth:  taitypes.AuthInfo{UserID: "user-owner"},
+	})
+}
+
+func newNodesRouter() *gin.Engine {
+	router := gin.New()
+	group := router.Group("/nodes")
+	nodes.Attach(group, authOAuth{})
+	return router
+}
+
+func listNodes(t *testing.T, router *gin.Engine, userID, teamID string) []map[string]interface{} {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/nodes", nil)
+	if userID != "" {
+		req.Header.Set("X-Test-User-ID", userID)
+	}
+	if teamID != "" {
+		req.Header.Set("X-Test-Team-ID", teamID)
+	}
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code, "body: %s", w.Body.String())
+
+	var result []map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	return result
+}
+
+func nodeIDs(nodes []map[string]interface{}) []string {
+	ids := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		if id, ok := n["tai_id"].(string); ok {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func TestListNodes_CloudVisibleToAll(t *testing.T) {
+	teardown := setupMockRegistry(t)
+	defer teardown()
+
+	reg := registry.Global()
+	registerCloudAndTunnelNodes(reg)
+
+	router := newNodesRouter()
+
+	ownerNodes := listNodes(t, router, "user-owner", "")
+	assert.ElementsMatch(t, []string{"tai-cloud", "tai-tunnel"}, nodeIDs(ownerNodes))
+
+	otherUserNodes := listNodes(t, router, "user-other", "")
+	assert.ElementsMatch(t, []string{"tai-cloud"}, nodeIDs(otherUserNodes))
+
+	thirdUserNodes := listNodes(t, router, "user-third", "")
+	assert.ElementsMatch(t, []string{"tai-cloud"}, nodeIDs(thirdUserNodes))
+}
+
+func TestListNodes_TunnelOnlyOwner(t *testing.T) {
+	teardown := setupMockRegistry(t)
+	defer teardown()
+
+	reg := registry.Global()
+	reg.Register(&registry.TaiNode{
+		TaiID: "tai-cloud",
+		Mode:  "cloud",
+	})
+	reg.Register(&registry.TaiNode{
+		TaiID: "tai-tunnel-user",
+		Mode:  "tunnel",
+		Auth:  taitypes.AuthInfo{UserID: "alice"},
+	})
+	reg.Register(&registry.TaiNode{
+		TaiID: "tai-tunnel-team",
+		Mode:  "tunnel",
+		Auth:  taitypes.AuthInfo{TeamID: "team-a"},
+	})
+
+	router := newNodesRouter()
+
+	aliceNodes := listNodes(t, router, "alice", "")
+	assert.Contains(t, nodeIDs(aliceNodes), "tai-tunnel-user")
+	assert.NotContains(t, nodeIDs(aliceNodes), "tai-tunnel-team")
+
+	bobNodes := listNodes(t, router, "bob", "")
+	assert.Contains(t, nodeIDs(bobNodes), "tai-cloud")
+	assert.NotContains(t, nodeIDs(bobNodes), "tai-tunnel-user")
+	assert.NotContains(t, nodeIDs(bobNodes), "tai-tunnel-team")
+
+	teamANodes := listNodes(t, router, "member-a", "team-a")
+	assert.Contains(t, nodeIDs(teamANodes), "tai-tunnel-team")
+	assert.NotContains(t, nodeIDs(teamANodes), "tai-tunnel-user")
+
+	teamBNodes := listNodes(t, router, "member-b", "team-b")
+	assert.Contains(t, nodeIDs(teamBNodes), "tai-cloud")
+	assert.NotContains(t, nodeIDs(teamBNodes), "tai-tunnel-team")
+}

--- a/openapi/nodes/oauth_stub_test.go
+++ b/openapi/nodes/oauth_stub_test.go
@@ -1,0 +1,103 @@
+package nodes_test
+
+import (
+	"context"
+
+	"github.com/gin-gonic/gin"
+	oauthTypes "github.com/yaoapp/yao/openapi/oauth/types"
+)
+
+// authOAuth is a minimal OAuth stub for Attach() in unit tests.
+// Guard injects auth from X-Test-User-ID / X-Test-Team-ID headers.
+type authOAuth struct{}
+
+var _ oauthTypes.OAuth = authOAuth{}
+
+func (authOAuth) Guard(c *gin.Context) {
+	c.Set("__subject", "test-subject")
+	c.Set("__client_id", "test-client")
+	c.Set("__scope", "openid profile")
+	if uid := c.GetHeader("X-Test-User-ID"); uid != "" {
+		c.Set("__user_id", uid)
+	}
+	if tid := c.GetHeader("X-Test-Team-ID"); tid != "" {
+		c.Set("__team_id", tid)
+	}
+	c.Next()
+}
+
+func (authOAuth) AuthorizationServer(context.Context) string { return "" }
+func (authOAuth) ProtectedResource(context.Context) string   { return "" }
+func (authOAuth) Authorize(context.Context, *oauthTypes.AuthorizationRequest) (*oauthTypes.AuthorizationResponse, error) {
+	return nil, nil
+}
+func (authOAuth) Token(context.Context, string, string, string, string) (*oauthTypes.Token, error) {
+	return nil, nil
+}
+func (authOAuth) Revoke(context.Context, string, string) error { return nil }
+func (authOAuth) Introspect(context.Context, string) (*oauthTypes.TokenIntrospectionResponse, error) {
+	return nil, nil
+}
+func (authOAuth) Register(context.Context, *oauthTypes.ClientInfo) (*oauthTypes.ClientInfo, error) {
+	return nil, nil
+}
+func (authOAuth) JWKS(context.Context) (*oauthTypes.JWKSResponse, error) { return nil, nil }
+func (authOAuth) Endpoints(context.Context) (map[string]string, error)   { return nil, nil }
+func (authOAuth) RefreshToken(context.Context, string, ...string) (*oauthTypes.RefreshTokenResponse, error) {
+	return nil, nil
+}
+func (authOAuth) DeviceAuthorization(context.Context, string, string) (*oauthTypes.DeviceAuthorizationResponse, error) {
+	return nil, nil
+}
+func (authOAuth) UserInfo(context.Context, string) (interface{}, error) { return nil, nil }
+func (authOAuth) GenerateCodeChallenge(context.Context, string, string) (string, error) {
+	return "", nil
+}
+func (authOAuth) ValidateCodeChallenge(context.Context, string, string, string) error { return nil }
+func (authOAuth) PushAuthorizationRequest(context.Context, *oauthTypes.PushedAuthorizationRequest) (*oauthTypes.PushedAuthorizationResponse, error) {
+	return nil, nil
+}
+func (authOAuth) TokenExchange(context.Context, string, string, string, string) (*oauthTypes.TokenExchangeResponse, error) {
+	return nil, nil
+}
+func (authOAuth) UpdateClient(context.Context, string, *oauthTypes.ClientInfo) (*oauthTypes.ClientInfo, error) {
+	return nil, nil
+}
+func (authOAuth) DeleteClient(context.Context, string) error { return nil }
+func (authOAuth) ValidateScope(context.Context, []string, string) (*oauthTypes.ValidationResult, error) {
+	return nil, nil
+}
+func (authOAuth) GetServerMetadata(context.Context) (*oauthTypes.AuthorizationServerMetadata, error) {
+	return nil, nil
+}
+func (authOAuth) ValidateResourceParameter(context.Context, string) (*oauthTypes.ValidationResult, error) {
+	return nil, nil
+}
+func (authOAuth) GetCanonicalResourceURI(context.Context, string) (string, error) { return "", nil }
+func (authOAuth) GetProtectedResourceMetadata(context.Context) (*oauthTypes.ProtectedResourceMetadata, error) {
+	return nil, nil
+}
+func (authOAuth) HandleWWWAuthenticate(context.Context, string) (*oauthTypes.WWWAuthenticateChallenge, error) {
+	return nil, nil
+}
+func (authOAuth) DynamicClientRegistration(context.Context, *oauthTypes.DynamicClientRegistrationRequest) (*oauthTypes.DynamicClientRegistrationResponse, error) {
+	return nil, nil
+}
+func (authOAuth) ValidateStateParameter(context.Context, string, string) (*oauthTypes.ValidationResult, error) {
+	return nil, nil
+}
+func (authOAuth) GenerateStateParameter(context.Context, string) (*oauthTypes.StateParameter, error) {
+	return nil, nil
+}
+func (authOAuth) ValidateTokenAudience(context.Context, string, string) (*oauthTypes.ValidationResult, error) {
+	return nil, nil
+}
+func (authOAuth) ValidateRedirectURI(context.Context, string, []string) (*oauthTypes.ValidationResult, error) {
+	return nil, nil
+}
+func (authOAuth) RotateRefreshToken(context.Context, string, ...string) (*oauthTypes.RefreshTokenResponse, error) {
+	return nil, nil
+}
+func (authOAuth) ValidateTokenBinding(context.Context, string, *oauthTypes.TokenBinding) (*oauthTypes.ValidationResult, error) {
+	return nil, nil
+}

--- a/openapi/oauth/types/types.go
+++ b/openapi/oauth/types/types.go
@@ -631,6 +631,9 @@ type AuthorizedInfo struct {
 	AuthSource string `json:"auth_source,omitempty"` // Authentication source preserved from login
 	OAuthEmail string `json:"oauth_email,omitempty"` // OAuth account email preserved from login
 
+	// Server-to-server authentication (cloud Tai nodes via Server Key)
+	Platform bool `json:"platform,omitempty"`
+
 	// Data access constraints (set by ACL enforcement)
 	Constraints DataConstraints `json:"constraints,omitempty"`
 }

--- a/openapi/sandbox/manage.go
+++ b/openapi/sandbox/manage.go
@@ -256,7 +256,7 @@ func handleList(c *gin.Context) {
 		snaps := reg.List()
 		for i := range snaps {
 			s := &snaps[i]
-			if s.Mode != "local" && !nodeOwnedBy(s, authInfo) {
+			if !taitypes.IsPublicNode(s.Mode) && !nodeOwnedBy(s, authInfo) {
 				continue
 			}
 			if !s.Capabilities.HostExec && !s.Capabilities.Docker {

--- a/openapi/setting/sandbox.go
+++ b/openapi/setting/sandbox.go
@@ -225,7 +225,7 @@ func handleSandboxGet(c *gin.Context) {
 	var filtered []taitypes.NodeMeta
 	for i := range snaps {
 		s := &snaps[i]
-		if s.Mode != "local" && !sandboxNodeOwnedBy(s, info) {
+		if !taitypes.IsPublicNode(s.Mode) && !sandboxNodeOwnedBy(s, info) {
 			continue
 		}
 		if !s.Capabilities.Docker {
@@ -244,8 +244,11 @@ func handleSandboxGet(c *gin.Context) {
 		go func(idx int, s taitypes.NodeMeta) {
 			defer wg.Done()
 			kind := "tai-link"
-			if s.Mode == "local" {
+			switch s.Mode {
+			case "local":
 				kind = "local"
+			case "cloud":
+				kind = "cloud"
 			}
 			node := ComputerNode{
 				NodeID:      s.TaiID,

--- a/openapi/setting/setup_status.go
+++ b/openapi/setting/setup_status.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yaoapp/yao/setting"
 	"github.com/yaoapp/yao/tai"
 	"github.com/yaoapp/yao/tai/registry"
+	taitypes "github.com/yaoapp/yao/tai/types"
 )
 
 // handleSetupStatus aggregates all system-level configuration checkpoints.
@@ -254,7 +255,7 @@ func checkSandboxNode(info *oauthTypes.AuthorizedInfo, isCN bool) Checkpoint {
 	}
 
 	for _, snap := range reg.List() {
-		if snap.Mode != "local" && !sandboxNodeOwnedBy(&snap, info) {
+		if !taitypes.IsPublicNode(snap.Mode) && !sandboxNodeOwnedBy(&snap, info) {
 			continue
 		}
 		if snap.Status == "online" && (snap.Capabilities.Docker || snap.Capabilities.HostExec) {
@@ -296,7 +297,7 @@ func checkSandboxImage(info *oauthTypes.AuthorizedInfo, locale string, isCN bool
 
 	downloaded := 0
 	for _, snap := range reg.List() {
-		if snap.Mode != "local" && !sandboxNodeOwnedBy(&snap, info) {
+		if !taitypes.IsPublicNode(snap.Mode) && !sandboxNodeOwnedBy(&snap, info) {
 			continue
 		}
 		if snap.Status != "online" || !snap.Capabilities.Docker {
@@ -530,7 +531,7 @@ func checkAssistantSandbox(ast *assistant.Assistant, info *oauthTypes.Authorized
 
 	dockerNodeFound := false
 	for _, snap := range reg.List() {
-		if snap.Mode != "local" && !sandboxNodeOwnedBy(&snap, info) {
+		if !taitypes.IsPublicNode(snap.Mode) && !sandboxNodeOwnedBy(&snap, info) {
 			continue
 		}
 		if snap.Status != "online" || !snap.Capabilities.Docker {

--- a/openapi/workspace/workspace.go
+++ b/openapi/workspace/workspace.go
@@ -265,8 +265,11 @@ func buildNodeMap() map[string]nodeInfo {
 	m := make(map[string]nodeInfo, len(nodes))
 	for _, n := range nodes {
 		kind := "node"
-		if n.Mode == "local" {
+		switch n.Mode {
+		case "local":
 			kind = "host"
+		case "cloud":
+			kind = "cloud"
 		}
 		name := n.DisplayName
 		if name == "" {

--- a/sandbox/v2/grpc.go
+++ b/sandbox/v2/grpc.go
@@ -13,8 +13,8 @@ const taiHost = "host.tai.internal"
 // All containers reach the host via "host.tai.internal" (injected by Tai at
 // container creation). The port depends on the mode:
 //
-//   - local:          Yao gRPC port (Tai and Yao on the same machine)
-//   - tunnel/direct:  Tai gRPC port (Tai Gateway forwards to Yao)
+//   - local:                   Yao gRPC port (Tai and Yao on the same machine)
+//   - tunnel/direct/cloud:     Tai gRPC port (Tai Gateway forwards to Yao)
 //
 // taiGRPCPort is the Tai node's gRPC port from registration (Ports.GRPC).
 func BuildGRPCEnv(mode string, taiGRPCPort int, sandboxID, chatID, workspaceID string) map[string]string {
@@ -36,7 +36,7 @@ func BuildGRPCEnv(mode string, taiGRPCPort int, sandboxID, chatID, workspaceID s
 		}
 		env["YAO_GRPC_ADDR"] = fmt.Sprintf("%s:%d", taiHost, port)
 
-	case "tunnel", "direct":
+	case "tunnel", "direct", "cloud":
 		port := taiGRPCPort
 		if port == 0 {
 			port = 19100

--- a/sandbox/v2/grpc_test.go
+++ b/sandbox/v2/grpc_test.go
@@ -57,6 +57,16 @@ func TestBuildGRPCEnv_Direct(t *testing.T) {
 	}
 }
 
+func TestBuildGRPCEnv_Cloud(t *testing.T) {
+	config.Conf.GRPC.Port = 9099
+	env := sandbox.BuildGRPCEnv("cloud", 19100, "sb-1", "chat-1", "ws-1")
+
+	want := "host.tai.internal:19100"
+	if env["YAO_GRPC_ADDR"] != want {
+		t.Errorf("YAO_GRPC_ADDR = %q, want %q", env["YAO_GRPC_ADDR"], want)
+	}
+}
+
 func TestBuildGRPCEnv_Direct_ZeroPort(t *testing.T) {
 	config.Conf.GRPC.Port = 9099
 	env := sandbox.BuildGRPCEnv("direct", 0, "sb-dzero", "", "")

--- a/sandbox/v2/manager.go
+++ b/sandbox/v2/manager.go
@@ -148,7 +148,7 @@ func (m *Manager) Create(ctx context.Context, opts CreateOptions) (*Box, error) 
 				nodeID = targetNode
 			} else {
 				nodeID = node
-				if nodeID == "local" {
+				if snap, ok := registry.Global().Get(nodeID); ok && taitypes.IsPublicNode(snap.Mode) {
 					if ws, e := wsm.Get(ctx, opts.WorkspaceID); e == nil && ws.Owner != "" && ws.Owner != opts.Owner {
 						return nil, fmt.Errorf("sandbox: no permission to mount workspace %q", opts.WorkspaceID)
 					}

--- a/sandbox/v2/manager_sandbox_test.go
+++ b/sandbox/v2/manager_sandbox_test.go
@@ -3,12 +3,15 @@ package sandbox_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	sandbox "github.com/yaoapp/yao/sandbox/v2"
+	"github.com/yaoapp/yao/tai/registry"
 	"github.com/yaoapp/yao/unit-test/agent/testprepare"
 	"github.com/yaoapp/yao/unit-test/agent/testprepare/sandboxtest"
+	"github.com/yaoapp/yao/workspace"
 )
 
 func TestManager_Create(t *testing.T) {
@@ -260,5 +263,122 @@ func TestManager_Nodes(t *testing.T) {
 	nodes := m.Nodes()
 	if len(nodes) == 0 {
 		t.Fatal("expected at least one registered node")
+	}
+}
+
+func createACLTestWorkspace(t *testing.T, nodeID, wsID, owner string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	_, err := workspace.M().Create(ctx, workspace.CreateOptions{
+		ID:    wsID,
+		Owner: owner,
+		Node:  nodeID,
+	})
+	if err != nil && !strings.Contains(err.Error(), "exists") {
+		t.Fatalf("create workspace %q: %v", wsID, err)
+	}
+	t.Cleanup(func() {
+		cCtx, cCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cCancel()
+		workspace.M().Delete(cCtx, wsID, true)
+	})
+}
+
+func TestWorkspaceACL_CloudNode(t *testing.T) {
+	testprepare.PrepareSandbox(t)
+	sandboxtest.RequireDocker(t)
+
+	m := sandbox.M()
+	nodeID := sandboxtest.TaiIDFromAddr(sandboxtest.TestLocalAddr())
+	meta, ok := registry.Global().Get(nodeID)
+	if !ok {
+		t.Fatalf("node %q not found in registry", nodeID)
+	}
+	origMode := meta.Mode
+	if !registry.SetNodeModeForTest(nodeID, "cloud") {
+		t.Fatalf("failed to set node %q mode to cloud", nodeID)
+	}
+	t.Cleanup(func() { registry.SetNodeModeForTest(nodeID, origMode) })
+
+	wsID := fmt.Sprintf("ws-acl-cloud-%d", time.Now().UnixNano())
+	createACLTestWorkspace(t, nodeID, wsID, "user-a")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	_, err := m.Create(ctx, sandbox.CreateOptions{
+		ID:          fmt.Sprintf("sb-acl-cloud-%d", time.Now().UnixNano()),
+		Image:       sandboxtest.TestImage(),
+		Owner:       "user-b",
+		NodeID:      nodeID,
+		WorkspaceID: wsID,
+	})
+	if err == nil {
+		t.Fatal("expected error when mounting another user's workspace on cloud node")
+	}
+	if !strings.Contains(err.Error(), "no permission to mount workspace") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWorkspaceACL_PublicNodes(t *testing.T) {
+	testprepare.PrepareSandbox(t)
+	sandboxtest.RequireDocker(t)
+
+	m := sandbox.M()
+	dockerNode := sandboxtest.TaiIDFromAddr(sandboxtest.TestLocalAddr())
+	dockerMeta, ok := registry.Global().Get(dockerNode)
+	if !ok {
+		t.Fatalf("node %q not found in registry", dockerNode)
+	}
+
+	cases := []struct {
+		name   string
+		nodeID string
+		setup  func(t *testing.T) func()
+	}{
+		{
+			name:   "local",
+			nodeID: "local",
+			setup: func(t *testing.T) func() {
+				return func() {}
+			},
+		},
+		{
+			name:   "cloud",
+			nodeID: dockerNode,
+			setup: func(t *testing.T) func() {
+				if !registry.SetNodeModeForTest(dockerNode, "cloud") {
+					t.Fatalf("failed to set node %q mode to cloud", dockerNode)
+				}
+				return func() { registry.SetNodeModeForTest(dockerNode, dockerMeta.Mode) }
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			restore := tc.setup(t)
+			defer restore()
+
+			wsID := fmt.Sprintf("ws-acl-pub-%s-%d", tc.name, time.Now().UnixNano())
+			createACLTestWorkspace(t, tc.nodeID, wsID, "user-a")
+
+			ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+			defer cancel()
+			_, err := m.Create(ctx, sandbox.CreateOptions{
+				ID:          fmt.Sprintf("sb-acl-pub-%s-%d", tc.name, time.Now().UnixNano()),
+				Image:       sandboxtest.TestImage(),
+				Owner:       "user-b",
+				NodeID:      tc.nodeID,
+				WorkspaceID: wsID,
+			})
+			if err == nil {
+				t.Fatalf("expected ACL error on %s public node", tc.name)
+			}
+			if !strings.Contains(err.Error(), "no permission to mount workspace") {
+				t.Fatalf("unexpected error on %s: %v", tc.name, err)
+			}
+		})
 	}
 }

--- a/sandbox/v2/types.go
+++ b/sandbox/v2/types.go
@@ -35,7 +35,7 @@ type ComputerInfo struct {
 	MachineID    string
 	Version      string
 	System       SystemInfo
-	Mode         string // "direct" | "tunnel"
+	Mode         string // "local" | "cloud" | "tunnel"
 	Capabilities map[string]bool
 	Status       string
 

--- a/setting/registry.go
+++ b/setting/registry.go
@@ -196,6 +196,12 @@ func (r *Registry) Reload() error {
 	return nil
 }
 
+// Flush forces immediate persistence of all pending writes in the backing store.
+// Must be called before process exit in CLI commands that write data.
+func (r *Registry) Flush() {
+	r.store.Flush()
+}
+
 // shallowMerge copies all keys from src into dst (overwrites existing keys).
 func shallowMerge(dst, src map[string]interface{}) {
 	for k, v := range src {

--- a/setting/serverkey.go
+++ b/setting/serverkey.go
@@ -1,0 +1,245 @@
+package setting
+
+import (
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+const (
+	serverKeyNS      = "server_keys"
+	serverKeyIndexNS = "server_keys_index"
+	serverKeyPrefix  = "yao-sk:"
+)
+
+// ServerKeyInfo holds non-secret metadata about a server key.
+type ServerKeyInfo struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	KeyHash   string `json:"key_hash"`
+	CreatedAt string `json:"created_at"`
+	ExpiresAt string `json:"expires_at,omitempty"`
+	Revoked   bool   `json:"revoked"`
+	LastUsed  string `json:"last_used,omitempty"`
+}
+
+// IsServerKeyFormat checks if the token has the server key prefix.
+func IsServerKeyFormat(token string) bool {
+	return len(token) > len(serverKeyPrefix) && token[:len(serverKeyPrefix)] == serverKeyPrefix
+}
+
+// HashServerKey returns the SHA-256 hex digest of a server key.
+func HashServerKey(key string) string {
+	h := sha256.Sum256([]byte(key))
+	return hex.EncodeToString(h[:])
+}
+
+// CreateServerKey generates a new server key with the given name and optional TTL.
+// Returns the plaintext key (shown once) and the key ID.
+// If ttl is 0, the key never expires.
+func CreateServerKey(name string, ttl ...time.Duration) (plainKey, keyID string, err error) {
+	if Global == nil {
+		return "", "", fmt.Errorf("setting registry not initialized")
+	}
+
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", "", fmt.Errorf("generate random key: %w", err)
+	}
+
+	plainKey = serverKeyPrefix + hex.EncodeToString(b)
+	keyHash := HashServerKey(plainKey)
+	keyID = "sk-" + hex.EncodeToString(b[:6])
+
+	scope := ScopeID{Scope: ScopeSystem}
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	keys, _ := Global.Get(scope, serverKeyNS)
+	if keys == nil {
+		keys = make(map[string]interface{})
+	}
+	entry := map[string]interface{}{
+		"name":       name,
+		"key_hash":   keyHash,
+		"created_at": now,
+		"revoked":    false,
+	}
+	if len(ttl) > 0 && ttl[0] > 0 {
+		entry["expires_at"] = time.Now().UTC().Add(ttl[0]).Format(time.RFC3339)
+	}
+	keys[keyID] = entry
+	if _, err := Global.Set(scope, serverKeyNS, keys); err != nil {
+		return "", "", fmt.Errorf("store server key: %w", err)
+	}
+
+	index, _ := Global.Get(scope, serverKeyIndexNS)
+	if index == nil {
+		index = make(map[string]interface{})
+	}
+	index[keyHash] = keyID
+	if _, err := Global.Set(scope, serverKeyIndexNS, index); err != nil {
+		return "", "", fmt.Errorf("store server key index: %w", err)
+	}
+
+	return plainKey, keyID, nil
+}
+
+// ValidateServerKey validates a plaintext server key.
+// Returns the key ID if valid, or an error if invalid/revoked.
+func ValidateServerKey(plainKey string) (keyID string, err error) {
+	if Global == nil {
+		return "", fmt.Errorf("setting registry not initialized")
+	}
+
+	keyHash := HashServerKey(plainKey)
+	scope := ScopeID{Scope: ScopeSystem}
+
+	index, _ := Global.Get(scope, serverKeyIndexNS)
+	if index == nil {
+		return "", fmt.Errorf("invalid server key")
+	}
+
+	idRaw, ok := index[keyHash]
+	if !ok {
+		return "", fmt.Errorf("invalid server key")
+	}
+	keyID, _ = idRaw.(string)
+	if keyID == "" {
+		return "", fmt.Errorf("invalid server key")
+	}
+
+	keys, _ := Global.Get(scope, serverKeyNS)
+	if keys == nil {
+		return "", fmt.Errorf("invalid server key")
+	}
+
+	entryRaw, ok := keys[keyID]
+	if !ok {
+		return "", fmt.Errorf("invalid server key")
+	}
+
+	m := normalizeMap(entryRaw)
+	if m == nil {
+		return "", fmt.Errorf("invalid server key")
+	}
+
+	if revoked, _ := m["revoked"].(bool); revoked {
+		return "", fmt.Errorf("server key has been revoked")
+	}
+
+	if expiresAt, _ := m["expires_at"].(string); expiresAt != "" {
+		if t, err := time.Parse(time.RFC3339, expiresAt); err == nil && time.Now().After(t) {
+			return "", fmt.Errorf("server key has expired")
+		}
+	}
+
+	return keyID, nil
+}
+
+// ListServerKeys returns metadata for all server keys.
+func ListServerKeys() ([]ServerKeyInfo, error) {
+	if Global == nil {
+		return nil, fmt.Errorf("setting registry not initialized")
+	}
+
+	scope := ScopeID{Scope: ScopeSystem}
+	keys, _ := Global.Get(scope, serverKeyNS)
+	if keys == nil {
+		return nil, nil
+	}
+
+	var result []ServerKeyInfo
+	for id, entryRaw := range keys {
+		m := normalizeMap(entryRaw)
+		if m == nil {
+			continue
+		}
+
+		info := ServerKeyInfo{ID: id}
+		info.Name, _ = m["name"].(string)
+		info.KeyHash, _ = m["key_hash"].(string)
+		info.CreatedAt, _ = m["created_at"].(string)
+		info.ExpiresAt, _ = m["expires_at"].(string)
+		info.Revoked, _ = m["revoked"].(bool)
+		info.LastUsed, _ = m["last_used"].(string)
+		result = append(result, info)
+	}
+	return result, nil
+}
+
+// RevokeServerKey marks a server key as revoked and removes it from the index.
+func RevokeServerKey(keyID string) error {
+	if Global == nil {
+		return fmt.Errorf("setting registry not initialized")
+	}
+
+	scope := ScopeID{Scope: ScopeSystem}
+	keys, _ := Global.Get(scope, serverKeyNS)
+	if keys == nil {
+		return fmt.Errorf("server key %q not found", keyID)
+	}
+
+	entryRaw, ok := keys[keyID]
+	if !ok {
+		return fmt.Errorf("server key %q not found", keyID)
+	}
+
+	m := normalizeMap(entryRaw)
+	if m == nil {
+		return fmt.Errorf("server key %q not found", keyID)
+	}
+
+	m["revoked"] = true
+	keys[keyID] = m
+	if _, err := Global.Set(scope, serverKeyNS, keys); err != nil {
+		return fmt.Errorf("revoke server key: %w", err)
+	}
+
+	keyHash, _ := m["key_hash"].(string)
+	if keyHash != "" {
+		index, _ := Global.Get(scope, serverKeyIndexNS)
+		if index != nil {
+			delete(index, keyHash)
+			Global.Set(scope, serverKeyIndexNS, index)
+		}
+	}
+
+	return nil
+}
+
+// UpdateServerKeyLastUsed updates last_used with 5-minute throttling.
+func UpdateServerKeyLastUsed(keyID string) {
+	if Global == nil {
+		return
+	}
+
+	scope := ScopeID{Scope: ScopeSystem}
+	keys, _ := Global.Get(scope, serverKeyNS)
+	if keys == nil {
+		return
+	}
+
+	entryRaw, ok := keys[keyID]
+	if !ok {
+		return
+	}
+
+	m := normalizeMap(entryRaw)
+	if m == nil {
+		return
+	}
+
+	if lastUsed, ok := m["last_used"].(string); ok && lastUsed != "" {
+		if t, err := time.Parse(time.RFC3339, lastUsed); err == nil {
+			if time.Since(t) < 5*time.Minute {
+				return
+			}
+		}
+	}
+
+	m["last_used"] = time.Now().UTC().Format(time.RFC3339)
+	keys[keyID] = m
+	Global.Set(scope, serverKeyNS, keys)
+}

--- a/setting/serverkey_test.go
+++ b/setting/serverkey_test.go
@@ -1,0 +1,77 @@
+package setting_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/yaoapp/yao/setting"
+)
+
+func TestIsServerKeyFormat(t *testing.T) {
+	tests := []struct {
+		token string
+		want  bool
+	}{
+		{"yao-sk:abc123def456", true},
+		{"yao-sk:x", true},
+		{"yao-sk:", false}, // prefix only, no content
+		{"yao-", false},    // API key prefix, not server key
+		{"yao-abc", false}, // API key
+		{"bearer-token", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := setting.IsServerKeyFormat(tt.token); got != tt.want {
+			t.Errorf("IsServerKeyFormat(%q) = %v, want %v", tt.token, got, tt.want)
+		}
+	}
+}
+
+func TestCreateServerKey(t *testing.T) {
+	setupRegistry(t)
+
+	plainKey, keyID, err := setting.CreateServerKey("test-node")
+	if err != nil {
+		t.Fatalf("CreateServerKey: %v", err)
+	}
+
+	if !strings.HasPrefix(plainKey, "yao-sk:") {
+		t.Errorf("plainKey should start with yao-sk:, got %q", plainKey)
+	}
+	if !strings.HasPrefix(keyID, "sk-") {
+		t.Errorf("keyID should start with sk-, got %q", keyID)
+	}
+}
+
+func TestValidateServerKey(t *testing.T) {
+	setupRegistry(t)
+
+	plainKey, _, err := setting.CreateServerKey("validate-test")
+	if err != nil {
+		t.Fatalf("CreateServerKey: %v", err)
+	}
+
+	// Valid key
+	keyID, err := setting.ValidateServerKey(plainKey)
+	if err != nil {
+		t.Fatalf("ValidateServerKey should succeed: %v", err)
+	}
+	if keyID == "" {
+		t.Error("keyID should not be empty")
+	}
+
+	// Invalid key
+	_, err = setting.ValidateServerKey("yao-sk:invalid-key")
+	if err == nil {
+		t.Error("ValidateServerKey should fail for invalid key")
+	}
+
+	// Revoked key
+	if err := setting.RevokeServerKey(keyID); err != nil {
+		t.Fatalf("RevokeServerKey: %v", err)
+	}
+	_, err = setting.ValidateServerKey(plainKey)
+	if err == nil {
+		t.Error("ValidateServerKey should fail for revoked key")
+	}
+}

--- a/tai/registry/registry.go
+++ b/tai/registry/registry.go
@@ -24,7 +24,7 @@ type TaiNode struct {
 	Version      string
 	Auth         types.AuthInfo
 	System       types.SystemInfo
-	Mode         string // "direct" | "tunnel"
+	Mode         string // "local" | "cloud" | "tunnel"
 	Addr         string // direct mode: "tai-host"; tunnel mode: empty
 	YaoBase      string // Yao server base URL reported by Tai (tunnel mode)
 	Ports        types.Ports
@@ -274,14 +274,14 @@ func (r *Registry) FindTaiIDByAuthClient(clientID string) string {
 	return ""
 }
 
-// ListByTeam returns metadata of all nodes belonging to the given team,
-// sorted by TaiID for deterministic order.
+// ListByTeam returns metadata of all nodes belonging to the given team
+// plus public nodes (local, cloud). Sorted by TaiID for deterministic order.
 func (r *Registry) ListByTeam(teamID string) []types.NodeMeta {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	var result []types.NodeMeta
 	for _, n := range r.nodes {
-		if n.Auth.TeamID == teamID {
+		if n.Auth.TeamID == teamID || types.IsPublicNode(n.Mode) {
 			result = append(result, n.meta())
 		}
 	}
@@ -292,13 +292,14 @@ func (r *Registry) ListByTeam(teamID string) []types.NodeMeta {
 }
 
 // ListByUser returns metadata of all nodes registered by the given user
-// that are NOT associated with any team. Sorted by TaiID for deterministic order.
+// (not associated with any team) plus public nodes (local, cloud).
+// Sorted by TaiID for deterministic order.
 func (r *Registry) ListByUser(userID string) []types.NodeMeta {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	var result []types.NodeMeta
 	for _, n := range r.nodes {
-		if n.Auth.TeamID == "" && n.Auth.UserID == userID {
+		if (n.Auth.TeamID == "" && n.Auth.UserID == userID) || types.IsPublicNode(n.Mode) {
 			result = append(result, n.meta())
 		}
 	}

--- a/tai/registry/registry_test.go
+++ b/tai/registry/registry_test.go
@@ -340,3 +340,61 @@ func TestNodeMeta_AuthInfo(t *testing.T) {
 		t.Errorf("Auth.Scope = %q, want tai:tunnel", snap.Auth.Scope)
 	}
 }
+
+func TestListByTeam_IncludesPublic(t *testing.T) {
+	r := newTestRegistry()
+	r.Register(&TaiNode{TaiID: "tai-cloud", Mode: "cloud"})
+	r.Register(&TaiNode{TaiID: "tai-tunnel", Mode: "tunnel", Auth: types.AuthInfo{TeamID: "team-a"}})
+
+	teamA := r.ListByTeam("team-a")
+	if len(teamA) != 2 {
+		t.Errorf("ListByTeam(team-a) = %d nodes, want 2", len(teamA))
+	}
+
+	ids := map[string]bool{}
+	for _, snap := range teamA {
+		ids[snap.TaiID] = true
+	}
+	for _, id := range []string{"tai-cloud", "tai-tunnel"} {
+		if !ids[id] {
+			t.Errorf("missing node %q in ListByTeam(team-a)", id)
+		}
+	}
+
+	teamB := r.ListByTeam("team-b")
+	if len(teamB) != 1 {
+		t.Errorf("ListByTeam(team-b) = %d nodes, want 1", len(teamB))
+	}
+	if teamB[0].TaiID != "tai-cloud" {
+		t.Errorf("ListByTeam(team-b) node = %q, want tai-cloud", teamB[0].TaiID)
+	}
+}
+
+func TestListByUser_IncludesPublic(t *testing.T) {
+	r := newTestRegistry()
+	r.Register(&TaiNode{TaiID: "tai-cloud", Mode: "cloud"})
+	r.Register(&TaiNode{TaiID: "tai-tunnel", Mode: "tunnel", Auth: types.AuthInfo{UserID: "user-1"}})
+
+	user1 := r.ListByUser("user-1")
+	if len(user1) != 2 {
+		t.Errorf("ListByUser(user-1) = %d nodes, want 2", len(user1))
+	}
+
+	ids := map[string]bool{}
+	for _, snap := range user1 {
+		ids[snap.TaiID] = true
+	}
+	for _, id := range []string{"tai-cloud", "tai-tunnel"} {
+		if !ids[id] {
+			t.Errorf("missing node %q in ListByUser(user-1)", id)
+		}
+	}
+
+	user2 := r.ListByUser("user-2")
+	if len(user2) != 1 {
+		t.Errorf("ListByUser(user-2) = %d nodes, want 1", len(user2))
+	}
+	if user2[0].TaiID != "tai-cloud" {
+		t.Errorf("ListByUser(user-2) node = %q, want tai-cloud", user2[0].TaiID)
+	}
+}

--- a/tai/registry/testing.go
+++ b/tai/registry/testing.go
@@ -18,3 +18,19 @@ func NewForTest() *Registry {
 func SetGlobalForTest(r *Registry) {
 	global = r
 }
+
+// SetNodeModeForTest updates the mode of a registered node for testing.
+// Not intended for production use.
+func SetNodeModeForTest(taiID, mode string) bool {
+	if global == nil {
+		return false
+	}
+	global.mu.Lock()
+	defer global.mu.Unlock()
+	n, ok := global.nodes[taiID]
+	if !ok {
+		return false
+	}
+	n.Mode = mode
+	return true
+}

--- a/tai/tunnel/grpc_handler.go
+++ b/tai/tunnel/grpc_handler.go
@@ -73,6 +73,11 @@ func (h *TunnelHandler) Register(stream taipb.TaiTunnel_RegisterServer) error {
 		}
 	}
 
+	mode := "tunnel"
+	if authInfo.Platform {
+		mode = "cloud"
+	}
+
 	node := &registry.TaiNode{
 		TaiID:        resolvedTaiID,
 		MachineID:    msg.MachineId,
@@ -80,7 +85,7 @@ func (h *TunnelHandler) Register(stream taipb.TaiTunnel_RegisterServer) error {
 		DisplayName:  msg.DisplayName,
 		Auth:         authInfo,
 		System:       systemFromProto(msg.System),
-		Mode:         "tunnel",
+		Mode:         mode,
 		Addr:         "tunnel://" + remoteIP,
 		Ports:        portsFromProto(msg.Ports),
 		Capabilities: capsFromProto(msg.Caps),
@@ -403,6 +408,7 @@ func authInfoFromStream(stream taipb.TaiTunnel_RegisterServer) types.AuthInfo {
 		Scope:    info.Scope,
 		TeamID:   info.TeamID,
 		TenantID: info.TenantID,
+		Platform: info.Platform,
 	}
 }
 

--- a/tai/tunnel/grpc_handler_test.go
+++ b/tai/tunnel/grpc_handler_test.go
@@ -648,7 +648,7 @@ func TestForwardConn_Read_Error(t *testing.T) {
 
 // ── authInfoFromStream with auth context ────────────────────────────────
 
-func startTestServerWithAuth(t *testing.T) (taipb.TaiTunnelClient, *TunnelHandler, func()) {
+func startTestServerWithAuth(t *testing.T, platform bool) (taipb.TaiTunnelClient, *TunnelHandler, func()) {
 	t.Helper()
 	reg := registry.NewForTest()
 	h := NewTunnelHandler(reg)
@@ -665,6 +665,7 @@ func startTestServerWithAuth(t *testing.T) (taipb.TaiTunnelClient, *TunnelHandle
 				Scope:    "workspace:read",
 				TeamID:   "team-1",
 				TenantID: "tenant-1",
+				Platform: platform,
 			})
 			return handler(srvObj, &wrappedStreamCtx{ServerStream: ss, ctx: ctx})
 		}),
@@ -1325,7 +1326,7 @@ vncDrained:
 }
 
 func TestRegister_WithAuthInfo(t *testing.T) {
-	client, h, cleanup := startTestServerWithAuth(t)
+	client, h, cleanup := startTestServerWithAuth(t, false)
 	defer cleanup()
 
 	stream, err := client.Register(context.Background())
@@ -1362,6 +1363,84 @@ func TestRegister_WithAuthInfo(t *testing.T) {
 	}
 	if node.Auth.Scope != "workspace:read" {
 		t.Errorf("expected scope=workspace:read, got %q", node.Auth.Scope)
+	}
+
+	stream.CloseSend()
+}
+
+func TestRegister_CloudMode(t *testing.T) {
+	client, h, cleanup := startTestServerWithAuth(t, true)
+	defer cleanup()
+
+	stream, err := client.Register(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = stream.Send(&taipb.TunnelControl{
+		Type:      "register",
+		NodeId:    "cloud-node",
+		MachineId: "cloud-machine",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Type != "registered" {
+		t.Fatalf("expected type=registered, got %q", resp.Type)
+	}
+
+	node, ok := h.reg.Get(resp.TaiId)
+	if !ok {
+		t.Fatal("node not found in registry")
+	}
+	if node.Mode != "cloud" {
+		t.Errorf("expected mode=cloud, got %q", node.Mode)
+	}
+	if !node.Auth.Platform {
+		t.Error("expected auth.platform=true for server key auth")
+	}
+
+	stream.CloseSend()
+}
+
+func TestRegister_TunnelMode(t *testing.T) {
+	client, h, cleanup := startTestServerWithAuth(t, false)
+	defer cleanup()
+
+	stream, err := client.Register(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = stream.Send(&taipb.TunnelControl{
+		Type:      "register",
+		NodeId:    "tunnel-mode-node",
+		MachineId: "tunnel-mode-machine",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := stream.Recv()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.Type != "registered" {
+		t.Fatalf("expected type=registered, got %q", resp.Type)
+	}
+
+	node, ok := h.reg.Get(resp.TaiId)
+	if !ok {
+		t.Fatal("node not found in registry")
+	}
+	if node.Mode != "tunnel" {
+		t.Errorf("expected mode=tunnel, got %q", node.Mode)
+	}
+	if node.Auth.Platform {
+		t.Error("expected auth.platform=false for OAuth auth")
 	}
 
 	stream.CloseSend()

--- a/tai/types/types.go
+++ b/tai/types/types.go
@@ -47,6 +47,7 @@ type AuthInfo struct {
 	Scope    string
 	TeamID   string
 	TenantID string
+	Platform bool // true for server-to-server auth (cloud nodes via Server Key)
 }
 
 // NodeMeta is the read-only metadata snapshot of a registered Tai node.
@@ -57,7 +58,7 @@ type NodeMeta struct {
 	Version      string
 	Auth         AuthInfo
 	System       SystemInfo
-	Mode         string // "direct" | "tunnel" | "local"
+	Mode         string // "local" | "cloud" | "tunnel"
 	Addr         string
 	YaoBase      string
 	Ports        Ports
@@ -66,4 +67,9 @@ type NodeMeta struct {
 	ConnectedAt  time.Time
 	LastPing     time.Time
 	DisplayName  string
+}
+
+// IsPublicNode returns true for node modes visible to all users (local and cloud).
+func IsPublicNode(mode string) bool {
+	return mode == "local" || mode == "cloud"
 }

--- a/tai/types/types_test.go
+++ b/tai/types/types_test.go
@@ -1,0 +1,26 @@
+package types_test
+
+import (
+	"testing"
+
+	"github.com/yaoapp/yao/tai/types"
+)
+
+func TestIsPublicNode(t *testing.T) {
+	tests := []struct {
+		mode string
+		want bool
+	}{
+		{"local", true},
+		{"cloud", true},
+		{"tunnel", false},
+		{"direct", false},
+		{"", false},
+		{"unknown", false},
+	}
+	for _, tt := range tests {
+		if got := types.IsPublicNode(tt.mode); got != tt.want {
+			t.Errorf("IsPublicNode(%q) = %v, want %v", tt.mode, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Added support for server key authentication in cloud nodes, allowing for server-to-server communication. Updated the authentication logic to differentiate between OAuth and server key methods, ensuring proper handling of node registration and access permissions. Enhanced related tests to verify the functionality of cloud node registration and authorization processes.