### PR TITLE
feat(presets): add OrcaRouter provider preset

### DIFF
--- a/llmprovider/presets.yml
+++ b/llmprovider/presets.yml
@@ -398,6 +398,67 @@
       capabilities: [tool_calls, streaming, json]
       enabled: false
 
+# ─── OrcaRouter ─────────────────────────────────────────
+- key: orcarouter
+  name: OrcaRouter
+  type: openai
+  api_url: https://api.orcarouter.ai/v1
+  require_key: true
+  default_models:
+    - id: orcarouter-auto
+      model: orcarouter/auto
+      name: Auto (Smart Route)
+      capabilities: [vision, tool_calls, streaming, json]
+      enabled: true
+    - id: orcarouter-fusion
+      model: orcarouter/fusion
+      name: Fusion
+      max_input_tokens: 1000000
+      capabilities: [vision, tool_calls, streaming, json, reasoning]
+      enabled: false
+    - id: orcarouter-fusion-flash
+      model: orcarouter/fusion-flash
+      name: Fusion Flash
+      max_input_tokens: 200000
+      capabilities: [tool_calls, streaming, json, reasoning]
+      enabled: false
+    - id: orcarouter-fusion-mini
+      model: orcarouter/fusion-mini
+      name: Fusion Mini
+      max_input_tokens: 1000000
+      capabilities: [tool_calls, streaming, json, reasoning]
+      enabled: false
+    - id: anthropic-claude-sonnet-4.6
+      model: anthropic/claude-sonnet-4.6
+      name: Claude Sonnet 4.6
+      max_input_tokens: 1000000
+      capabilities: [vision, tool_calls, streaming, json, reasoning]
+      enabled: false
+    - id: deepseek-deepseek-v4-flash
+      model: deepseek/deepseek-v4-flash
+      name: DeepSeek V4 Flash
+      max_input_tokens: 1048576
+      capabilities: [tool_calls, streaming, json]
+      enabled: false
+    - id: google-gemini-3.1-pro-preview
+      model: google/gemini-3.1-pro-preview
+      name: Gemini 3.1 Pro
+      max_input_tokens: 1048576
+      capabilities: [vision, tool_calls, streaming, json, reasoning]
+      enabled: false
+    - id: qwen-qwen3.7-max
+      model: qwen/qwen3.7-max
+      name: Qwen3.7 Max
+      max_input_tokens: 1000000
+      capabilities: [tool_calls, streaming, json]
+      enabled: false
+    - id: z-ai-glm-5.2
+      model: z-ai/glm-5.2
+      name: GLM-5.2
+      max_input_tokens: 1000000
+      capabilities: [tool_calls, streaming, json]
+      enabled: false
+
 # ─── 超算互联网 Token Plan (OpenAI) ─────────────────────
 - key: scnet_token_plan
   name: 超算互联网 Token Plan


### PR DESCRIPTION
This adds **OrcaRouter** as a first-class provider preset in the LLM provider picker, so Yao users can connect agents to OrcaRouter's OpenAI-compatible gateway in a couple of clicks instead of pasting a custom base URL.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` as a named preset means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The entry mirrors the existing `openrouter` preset in `llmprovider/presets.yml`: `type: openai`, `api_url: https://api.orcarouter.ai/v1`, `require_key: true`, and a set of `default_models` that route through OrcaRouter's `provider/model` namespace (e.g. `orcarouter/auto`, `orcarouter/fusion`, plus Anthropic/DeepSeek/Google/Qwen/Z-AI models). I verified the endpoint and the preset's model IDs with a real `chat/completions` call to `https://api.orcarouter.ai/v1` (HTTP 200, valid responses for `orcarouter/auto`, `orcarouter/fusion`, and `orcarouter/fusion-flash`), and confirmed the updated `presets.yml` parses cleanly with the same `gopkg.in/yaml.v3` schema used by `llmprovider`.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
