### PR TITLE
chore(workflows): update pnpm version to 8 in CI configurations

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -22,7 +22,7 @@ jobs:
           node-version: 18
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@8
 
       - name: Setup Cache
         uses: actions/cache@v4

--- a/.github/workflows/debug-build-windows.yml
+++ b/.github/workflows/debug-build-windows.yml
@@ -80,7 +80,7 @@ jobs:
           node-version: 18
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@8
 
       - name: Setup Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 18
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@8
 
       - name: Setup Cache
         uses: actions/cache@v4

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -101,7 +101,7 @@ jobs:
           node-version: 18
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        run: npm install -g pnpm@8
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Modified the installation command for pnpm in the macOS and Windows workflow files to specify version 8. This ensures consistency across build environments and leverages the latest features and improvements of pnpm.