### PR TITLE
fix(readme): update Discord invite link in English and Chinese README…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,4 @@ Let your agents become part of your business, wherever you need them.
 - Docs: https://yaoagents.com/docs
 - Yao Desktop: https://yaoagents.com/download
 - Android (Beta): https://get.yaoapps.com/yaoagents/cui-android/0.6.37/cui-android-0.6.37.apk
-- Discord: https://discord.gg/yao
+- Discord: https://discord.com/invite/BkMR2NUsjU

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -52,4 +52,4 @@ Agent 运行在你自己的设备上。每添加一台机器，就多一个它�
 - 文档：https://yaoagents.com/docs
 - Yao Desktop：https://yaoagents.com/download
 - Android 客户端（公测）：https://get.yaoapps.com/yaoagents/cui-android/0.6.37/cui-android-0.6.37.apk
-- Discord：https://discord.gg/yao
+- Discord：https://discord.com/invite/BkMR2NUsjU


### PR DESCRIPTION
… files

Replaced the Discord invite link in both the English and Chinese versions of the README files to the new URL format, ensuring users have the correct access to the community. This change enhances the accuracy of the documentation.